### PR TITLE
Fix crash when multitap is enabled

### DIFF
--- a/mednafen/ss/smpc.cpp
+++ b/mednafen/ss/smpc.cpp
@@ -268,6 +268,7 @@ static void MapPorts(void)
    for(unsigned i = 0; i < 6; i++)
    {
     IODevice* const tsd = VirtualPorts[vp++];
+    if (!tsd) continue; // libretro fix - patch for multi-tap set on startup.
 
     if(SPorts[sp]->GetSubDevice(i) != tsd)
      tsd->Power();


### PR DESCRIPTION
This old fix was lost with the 1.26.0 update it seems: https://github.com/libretro/beetle-saturn-libretro/commit/b532821034160a993e88c4b8b24468123d747ba3#diff-186a68c9576805816b4913656107ed05f9dcb587ffe77d9ccecd71e9099f0bfeL266

Tested with 6 players on Guardian Heroes, seems to work fine. Closes #8