### PR TITLE
Fix savestate loading

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -32,7 +32,7 @@
 
 #define MEDNAFEN_CORE_NAME                   "Beetle Saturn"
 #define MEDNAFEN_CORE_VERSION                "v1.29.0"
-#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102403
+#define MEDNAFEN_CORE_VERSION_NUMERIC        0x00102900
 #define MEDNAFEN_CORE_EXTENSIONS             "cue|ccd|chd|toc|m3u"
 #define MEDNAFEN_CORE_TIMING_FPS             59.82
 #define MEDNAFEN_CORE_GEOMETRY_BASE_W        320

--- a/mednafen/state.cpp
+++ b/mednafen/state.cpp
@@ -405,11 +405,11 @@ int MDFNSS_LoadSM(void *st_p, uint32_t ver)
 	if ( memcmp( header, "MDFNSVST", 8 ) )
 		return(0);
 
-	// Different core version?
+	// Unsupported state version?
 	stateversion = MDFN_de32lsb( header + 16 );
-	if ( stateversion != ver )
+	if ( stateversion < 0x900 )
 		return(0);
 
 	// Call out to main save state function.
-	return LibRetro_StateAction( st, 1 /*LOAD*/);
+	return LibRetro_StateAction( st, stateversion /*LOAD*/);
 }


### PR DESCRIPTION
Must set `LibRetro_StateAction`'s `load` to the version field of the state being loaded. Also allows loading older savestate versions.

Fixes #13