### PR TITLE
Backport from libretro-mirrors

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -187,7 +187,8 @@ SOURCES_C += 	 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
 		 $(LIBRETRO_COMM_DIR)/time/rtime.c
 
 ifeq ($(NEED_THREADING), 1)
-SOURCES_C += $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c
+SOURCES_C +=	 $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+		 $(LIBRETRO_COMM_DIR)/rthreads/rsemaphore.c
 endif
 
 endif


### PR DESCRIPTION
Backport changes from PR's [191](https://github.com/libretro-mirrors/beetle-saturn-libretro/pull/191), [197](https://github.com/libretro-mirrors/beetle-saturn-libretro/pull/197), and [199](https://github.com/libretro-mirrors/beetle-saturn-libretro/pull/199) by [jdgleaver](https://github.com/jdgleaver).

Current master suffers from a performance penalty (at least under Windows) that prevents reducing the audio latency below
a certain threshold (25-30ms for me).

Issue appears to be caused by lack of rsemaphore referencing for VDP2 "busy wait".

These changes improve performance and allow for latency to be further reduced.

Tested on WIndows 11 using WASAPI audio driver.
