### PR TITLE
Avoid malloc & memcpy in retro_serialize

### DIFF
--- a/mednafen/state.cpp
+++ b/mednafen/state.cpp
@@ -46,7 +46,16 @@ int32_t smem_write(StateMem *st, void *buffer, uint32_t len)
 
       while(newsize < (len + st->loc))
          newsize *= 2;
-      st->data = (uint8_t *)realloc(st->data, newsize);
+
+      // Don't realloc data_frontend memory
+      if (st->data == st->data_frontend && st->data != NULL)
+      {
+         st->data = (uint8_t *)malloc(newsize);
+         memcpy(st->data, st->data_frontend, st->malloced);
+      }
+      else
+         st->data = (uint8_t *)realloc(st->data, newsize);
+
       st->malloced = newsize;
    }
    memcpy(st->data + st->loc, buffer, len);

--- a/mednafen/state.h
+++ b/mednafen/state.h
@@ -28,6 +28,7 @@
 typedef struct
 {
    uint8_t *data;
+   uint8_t *data_frontend; // never realloc'd
    uint32_t loc;
    uint32_t len;
    uint32_t malloced;


### PR DESCRIPTION
Improves Preemptive Frames and RunAhead performance by saving states directly to the passed-in buffer.

If the passed-in size is too small, MDFNSS_SaveSM will now malloc separate memory to complete the save, then retro_serialize frees it and returns false.