### PR TITLE
Fix aspect ratio and default cropping

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -484,9 +484,9 @@ void input_init(void)
 	}
 }
 
-void input_set_geometry( unsigned width, unsigned height )
+void input_set_geometry(unsigned width, unsigned height)
 {
-	log_cb( RETRO_LOG_INFO, "input_set_geometry: %dx%d\n", width, height );
+	log_cb(RETRO_LOG_INFO, "%s: %dx%d\n", __func__, width, height);
 
 	geometry_width = width;
 	geometry_height = height;

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -772,12 +772,10 @@ void retro_run(void)
 
       environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 
-      log_cb(RETRO_LOG_INFO, "Target framebuffer size : %dx%d\n", width, height);
-
       game_width  = width;
       game_height = height;
 
-      input_set_geometry( width, height );
+      input_set_geometry(width, height);
    }
 
    /* LED interface */
@@ -832,9 +830,9 @@ void retro_deinit(void)
    delete surf;
    surf = NULL;
 
-   log_cb(RETRO_LOG_INFO, "[%s]: Samples / Frame: %.5f\n",
+   log_cb(RETRO_LOG_DEBUG, "[%s]: Samples / Frame: %.5f\n",
          MEDNAFEN_CORE_NAME, (double)audio_frames / video_frames);
-   log_cb(RETRO_LOG_INFO, "[%s]: Estimated FPS: %.5f\n",
+   log_cb(RETRO_LOG_DEBUG, "[%s]: Estimated FPS: %.5f\n",
          MEDNAFEN_CORE_NAME, (double)video_frames * 44100 / audio_frames);
  
    libretro_supports_option_categories = false;
@@ -843,9 +841,7 @@ void retro_deinit(void)
 
 unsigned retro_get_region(void)
 {
-   if (is_pal)
-       return RETRO_REGION_PAL;  //Ben Swith PAL
-   return RETRO_REGION_NTSC;
+   return (is_pal) ? RETRO_REGION_PAL : RETRO_REGION_NTSC;
 }
 
 unsigned retro_api_version(void)

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -757,13 +757,19 @@ void retro_run(void)
    {
       struct retro_system_av_info av_info;
 
-      // Change frontend resolution using  base width/height (+ overscan adjustments).
+      // Change frontend resolution using base width/height (+ overscan adjustments).
       // This avoids inconsistent frame scales when game switches between interlaced and non-interlaced modes.
       av_info.geometry.base_width   = 352 - h_mask;
       av_info.geometry.base_height  = linevislast + 1 - linevisfirst;
       av_info.geometry.max_width    = MEDNAFEN_CORE_GEOMETRY_MAX_W;
       av_info.geometry.max_height   = MEDNAFEN_CORE_GEOMETRY_MAX_H;
-      av_info.geometry.aspect_ratio = MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO;
+      av_info.geometry.aspect_ratio = 352.0f / ((is_pal) ? 256.0f : 240.0f);
+      av_info.geometry.aspect_ratio *= 6.0f / 7.0f;
+
+      /* Corrections for croppings */
+      av_info.geometry.aspect_ratio *= ((is_pal) ? 288.0f : 240.0f) / av_info.geometry.base_height;
+      av_info.geometry.aspect_ratio /= 352.0f / (352 - h_mask);
+
       environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 
       log_cb(RETRO_LOG_INFO, "Target framebuffer size : %dx%d\n", width, height);
@@ -816,9 +822,9 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.aspect_ratio = MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO;
 
    if (retro_get_region() == RETRO_REGION_PAL)
-      info->timing.fps            = 49.96;
+      info->timing.fps            = 49.92012779552716;
    else
-      info->timing.fps            = 59.88;
+      info->timing.fps            = 59.82650314089141;
 }
 
 void retro_deinit(void)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -164,7 +164,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "40",       NULL },
          { NULL, NULL },
       },
-      "0"
+      "8"
    },
    {
       "beetle_saturn_last_scanline",
@@ -206,7 +206,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "239",       NULL },
          { NULL, NULL },
       },
-      "239"
+      "231"
    },
    {
       "beetle_saturn_initial_scanline_pal",
@@ -279,7 +279,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "60",       NULL },
          { NULL, NULL },
       },
-      "0"
+      "16"
    },
    {
       "beetle_saturn_last_scanline_pal",


### PR DESCRIPTION
- More accurate pixel aspect ratio based on multiple images from real hardware and other data
- Preserve aspect ratio when using cropping or masking
- Changed default cropping modes to the usual values for both PAL and NTSC (PAL for some reason already deafulted only last scanline to that value)
- Adjusted fps to be a bit more accurate based on core offered timing
- Removed and hid some pointless double logging + cleanups