### PR TITLE
Add more upstream 1.31 changes.

### DIFF
--- a/mednafen/hash/sha256.h
+++ b/mednafen/hash/sha256.h
@@ -25,6 +25,52 @@
 #include <array>
 
 typedef std::array<uint8, 32> sha256_digest;
+class sha256_hasher
+{
+ public:
+
+ sha256_hasher();
+
+ void reset(void);
+
+ void process(const void* data, size_t len);
+
+ INLINE void process_cstr(const char* s)
+ {
+  return process(s, strlen(s));
+ }
+
+ template<typename T>
+ INLINE void process_scalar(const T v)
+ {
+  if(std::is_same<T, bool>::value)
+  {
+   uint8 tmp = v;
+
+   process(&tmp, 1);
+  }
+  else
+  {
+   alignas(T) uint8 tmp[sizeof(T)];
+
+   MDFN_enlsb(&tmp[0], v, sizeof(v[0]));
+
+   process(tmp, sizeof(tmp));
+  }
+ }
+
+ sha256_digest digest(void) const;
+
+ private:
+
+ void process_block(const uint8* data);
+ std::array<uint32, 8> h;
+
+ uint8 buf[64];
+ size_t buf_count;
+
+ uint64 bytes_processed;
+};
 
 void sha256_test(void);
 sha256_digest sha256(const void* data, const uint64 len);

--- a/mednafen/mednafen-endian.h
+++ b/mednafen/mednafen-endian.h
@@ -79,6 +79,14 @@ static inline void MDFN_en32lsb(uint8_t *buf, uint32_t morp)
  buf[3]=morp>>24;
 }
 
+static inline void MDFN_enlsb(void* buf, void* value, size_t size)
+{
+ if (size == 2) // 16 bits (2 bytes)
+  MDFN_en16lsb((uint8_t*)buf, *(uint16_t*)value);
+ else if (size == 4) // 32 bits (4 bytes)
+  MDFN_en32lsb((uint8_t*)buf, *(uint32_t*)value);
+}
+
 static inline void MDFN_en16msb(uint8_t *buf, uint16_t morp)
 {
  buf[0] = morp >> 8;

--- a/mednafen/ss/cart.cpp
+++ b/mednafen/ss/cart.cpp
@@ -28,7 +28,7 @@
 #include "cart.h"
 #include "cart/backup.h"
 #include "cart/cs1ram.h"
-#include "cart/debug.h"
+#include "cart/bootrom.h"
 #include "cart/extram.h"
 //#include "cart/nlmodem.h"
 #include "cart/rom.h"
@@ -191,9 +191,21 @@ void CART_Init(const int cart_type)
 	CART_CS1RAM_Init(&Cart);
 	break;
 
-  case CART_MDFN_DEBUG:
-	CART_Debug_Init(&Cart);
-	break;
+  case CART_BOOTROM:
+   {
+        const std::string path_cxx = MDFN_GetSettingS("ss.cart.bootrom_path");
+        const char *path = MDFN_MakeFName(MDFNMKF_FIRMWARE, 0, path_cxx.c_str());
+        RFILE      *fp   = filestream_open(path,
+              RETRO_VFS_FILE_ACCESS_READ,
+              RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+        if (fp)
+        {
+           CART_BootROM_Init(&Cart, fp);
+           filestream_close(fp);
+        }
+    }
+        break;
 
 //  case CART_NLMODEM:
 //	CART_NLModem_Init(&Cart);

--- a/mednafen/ss/cart.h
+++ b/mednafen/ss/cart.h
@@ -90,7 +90,7 @@ enum
 
  CART_NLMODEM	 = 0x600,
 
- CART_MDFN_DEBUG = 0xF00
+ CART_BOOTROM = 0xF00
 };
 
 void CART_Init(const int cart_type) MDFN_COLD;

--- a/mednafen/ss/cart/bootrom.cpp
+++ b/mednafen/ss/cart/bootrom.cpp
@@ -1,0 +1,117 @@
+/******************************************************************************/
+/* Mednafen Sega Saturn Emulation Module                                      */
+/******************************************************************************/
+/* bootrom.cpp - Bootable ROM cart emulation
+**  Copyright (C) 2017-2023 Mednafen Team
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software Foundation, Inc.,
+** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#include "common.h"
+#include "bootrom.h"
+#include "backup.h"
+
+#include <mednafen/hash/sha256.h>
+
+static uint16* ROM = nullptr;
+static uint32 ROM_Mask[2];
+
+static MDFN_HOT void CS0_ROM_Read(uint32 A, uint16* DB)
+{
+ const uint32 offs = (A - 0x02000000) & ROM_Mask[0];
+
+ *DB = ne16_rbo_be<uint16>(ROM, offs);
+}
+
+static MDFN_HOT void CS1_ROM_Read(uint32 A, uint16* DB)
+{
+ const uint32 offs = 0x02000000 + ((A - 0x04000000) & ROM_Mask[1]);
+
+ *DB = ne16_rbo_be<uint16>(ROM, offs);
+}
+
+static MDFN_COLD void Kill(void)
+{
+ if(ROM)
+ {
+  delete[] ROM;
+  ROM = nullptr;
+ }
+}
+
+void CART_BootROM_Init(CartInfo* c, RFILE* str)
+{
+ try
+ {
+  const uint64 ss = filestream_get_size(str);
+  const uint64 min_size = 1;
+  const uint64 max_size = 0x3000000;
+
+  if(ss < min_size)
+   throw MDFN_Error(0, _("Bootable Saturn cart ROM image is smaller than the minimum of %llu bytes."), (unsigned long long)min_size);
+
+  if(ss > max_size)
+  throw MDFN_Error(0, _("Bootable Saturn cart ROM image is larger than the maximum of %llu bytes."), (unsigned long long)max_size);
+  //
+  //
+  uint32 ROM_Size;
+
+  if(ss > 0x2000000)
+   ROM_Size = 0x2000000 + round_up_pow2((ss - 0x2000000 + 0xFFFF) &~ 0xFFFF);
+  else
+   ROM_Size = round_up_pow2((ss + 0xFFFF) &~ 0xFFFF);
+
+  assert(ROM_Size >= ss);
+  //
+  //
+  sha256_hasher h;
+  sha256_digest dig;
+
+  ROM = new uint16[ROM_Size / sizeof(uint16)];
+  memset(ROM, 0x00, ROM_Size);
+  filestream_read(str, ROM, ss);
+  h.process(ROM, ss);
+  dig = h.digest();
+  memcpy(MDFNGameInfo->MD5, dig.data(), 16);
+
+  for(unsigned i = 0; i < ROM_Size / sizeof(uint16); i++)
+   ROM[i] = MDFN_de16msb<true>(&ROM[i]);
+
+  SS_SetPhysMemMap (0x02000000, 0x03FFFFFF, ROM, std::min<uint32>(0x02000000, ROM_Size), false);
+  c->CS01_SetRW8W16(0x02000000, 0x03FFFFFF, CS0_ROM_Read);
+
+  c->Kill = Kill;
+
+  ROM_Mask[0] = (round_up_pow2(ROM_Size) - 1) & 0x01FFFFFE;
+
+  if(ROM_Size > 0x2000000)
+  {
+   ROM_Mask[1] = (round_up_pow2(ROM_Size - 0x2000000) - 1) & 0x00FFFFFE;
+
+   SS_SetPhysMemMap (0x04000000, 0x04FFFFFF, ROM + (0x02000000 / sizeof(uint16)), ROM_Size - 0x02000000, false);
+   c->CS01_SetRW8W16(0x04000000, 0x04FFFFFF, CS1_ROM_Read);
+  }
+  else
+  {
+   CART_Backup_Init(c);
+   assert(c->Kill == Kill);
+  }
+ }
+ catch(...)
+ {
+  Kill();
+  throw;
+ }
+}

--- a/mednafen/ss/cart/bootrom.h
+++ b/mednafen/ss/cart/bootrom.h
@@ -1,0 +1,29 @@
+/******************************************************************************/
+/* Mednafen Sega Saturn Emulation Module                                      */
+/******************************************************************************/
+/* bootrom.h - Bootable ROM cart emulation
+**  Copyright (C) 2023 Mednafen Team
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software Foundation, Inc.,
+** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#ifndef __MDFN_SS_CART_BOOTROM_H
+#define __MDFN_SS_CART_BOOTROM_H
+
+#include <streams/file_stream.h>
+
+void CART_BootROM_Init(CartInfo* c, RFILE* str) MDFN_COLD;
+
+#endif

--- a/mednafen/ss/ss.cpp
+++ b/mednafen/ss/ss.cpp
@@ -2,7 +2,7 @@
 /* Mednafen Sega Saturn Emulation Module                                      */
 /******************************************************************************/
 /* ss.cpp - Saturn Core Emulation and Support Functions
-**  Copyright (C) 2015-2021 Mednafen Team
+**  Copyright (C) 2015-2023 Mednafen Team
 **
 ** This program is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU General Public License
@@ -863,7 +863,7 @@ bool MDFN_COLD InitCommon(const unsigned cpucache_emumode, const unsigned horrib
          { CART_ULTRAMAN, "Ultraman ROM" },
          { CART_CS1RAM_16M, _("16MiB CS1 RAM") },
          { CART_NLMODEM, _("Netlink Modem") },
-         { CART_MDFN_DEBUG, "Mednafen Debug" }
+         { CART_BOOTROM, _("Bootable ROM") } 
       };
       const char* cn = nullptr;
 
@@ -910,7 +910,7 @@ bool MDFN_COLD InitCommon(const unsigned cpucache_emumode, const unsigned horrib
    MDFNMP_RegSearchable(0x06000000, WORKRAM_BANK_SIZE_BYTES);
 
    CART_Init(cart_type);
-  ActiveCartType = cart_type;
+   ActiveCartType = cart_type;
 
    //
    //


### PR DESCRIPTION
Add more upstream 1.31 changes:
-Swap cart/debug.* for cart/bootrom.* and use CART_BOOTROM instead of CART_MDFN_DEBUG in ss.cpp
-Add sha256 "sha256_hasher" class needed for bootrom.* to build.
-Add MDFN_enlsb() to mednafen-endian needed by "sha256_hasher" class. This was done in C to avoid the extra mile of switching to the new C++ endian code.

This commit was mostly "aesthetic", I guess.