### PR TITLE
Remove erroneous free() call in zlib_codec_init()

### DIFF
--- a/deps/libchdr/src/libchdr_chd.c
+++ b/deps/libchdr/src/libchdr_chd.c
@@ -2525,10 +2525,6 @@ static chd_error zlib_codec_init(void *codec, uint32_t hunkbytes)
 	else
 		err = CHDERR_NONE;
 
-	/* handle an error */
-	if (err != CHDERR_NONE)
-		free(data);
-
 	return err;
 }
 


### PR DESCRIPTION
Remove a free() call inherited from the original MAME code which allocated memory within zlib_codec_init(). It is no longer appropriate to call here, as the data variable now points to the middle of a caller-owned allocation.