### PR TITLE
Added basic support for loongarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ else ifneq (,$(findstring armv,$(platform)))
    override platform += unix
 endif
 
+ifeq ($(platform), unix)
+   ifeq ($(shell uname -m),loongarch64)
+      arch = loongarch64
+   endif
+endif
+
 ifneq ($(platform), osx)
    ifeq ($(findstring Haiku,$(shell uname -s)),)
       PTHREAD_FLAGS = -pthread
@@ -55,6 +61,12 @@ endif
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
    CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
+# loongarch
+ifeq ($(arch),loongarch64)
+   libdir := $(libdir)/loongarch64-linux-gnu
+   CXXFLAGS += -D__loongarch64__
 endif
 
 # Unix

--- a/mednafen/ss/scu_dsp_common.inc
+++ b/mednafen/ss/scu_dsp_common.inc
@@ -19,7 +19,7 @@
 ** 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(__arm64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__ppce64le__)
+#if defined(__loongarch64__) || defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(__arm64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__ppce64le__)
  #define DSP_INSTR_BASE_UIPT ((uintptr_t)DSP_Init)
  #define DSP_INSTR_RECOVER_TCAST int32
 #else


### PR DESCRIPTION
The core builds and runs in Retroarch with these changes. Without them, the DSP emulator doesn't have the right definitions to turn emulated instruction addresses into real ones (I think. I'm not a C genius. [Look here for what wasn't working](https://github.com/libretro/beetle-saturn-libretro/blob/ccba5265f60f8e64a1984c9d14d383606193ea6a/mednafen/ss/scu.inc#L1647). It would compute a ludicrously low number and then try to void * void it and segfault.)  

I'm running Debian (6.16.3+deb14-loong64) on a 3A6000-based system.  Using RetroArch 1.20.0 and a bin-cue of Tempest 2000 to test.