### PR TITLE
Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 *.exp
 *.manifest
 *.d
+*.data
+*.old
 mednafen/hw_cpu/m68k/gen
 mednafen/hw_cpu/m68k/gen_split

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 *.lib
 *.exp
 *.manifest
+*.d
 mednafen/hw_cpu/m68k/gen
 mednafen/hw_cpu/m68k/gen_split

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DEBUG = 0
 HAVE_OPENGL = 0
 HAVE_CHD = 1
 HAVE_CDROM = 0
+LTO = 1
 
 CORE_DIR := .
 
@@ -407,6 +408,11 @@ ifeq ($(DEBUG),0)
    FLAGS += -O2 $(EXTRA_GCC_FLAGS)
 else
    FLAGS += -O0 -g
+endif
+
+ifneq ($(LTO),)
+   FLAGS   += -flto=auto -fipa-pta
+   LDFLAGS += -flto=auto -fipa-pta -O2
 endif
 
 LDFLAGS += $(fpic) $(SHARED)

--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,7 @@ ifeq ($(NO_GCC),1)
 endif
 
 OBJECTS := $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o)
+DEPS    := $(OBJECTS:.o=.d)
 
 all: $(TARGET)
 
@@ -419,6 +420,8 @@ CFLAGS   += $(FLAGS)
 
 ifeq (,$(findstring msvc,$(platform)))
     CXXFLAGS += -std=c++11
+    CFLAGS   += -MMD -MP
+    CXXFLAGS += -MMD -MP
 endif
 
 OBJOUT   = -o
@@ -452,7 +455,7 @@ endif
 	$(CC) -c $(OBJOUT)$@ $< $(CFLAGS)
 
 clean:
-	rm -f $(TARGET) $(OBJECTS)
+	rm -f $(TARGET) $(OBJECTS) $(DEPS)
 
 install:
 	install -D -m 755 $(TARGET) $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET)
@@ -461,3 +464,5 @@ uninstall:
 	rm $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET)
 
 .PHONY: clean install uninstall
+
+-include $(DEPS)

--- a/libretro-common/vfs/vfs_implementation.d
+++ b/libretro-common/vfs/vfs_implementation.d
@@ -1,8 +1,0 @@
-libretro-common/vfs/vfs_implementation.o: \
- libretro-common/vfs/vfs_implementation.c \
- libretro-common/include/vfs/vfs_implementation.h \
- libretro-common/include/libretro.h libretro-common/include/memmap.h \
- libretro-common/include/encodings/utf.h \
- libretro-common/include/boolean.h \
- libretro-common/include/retro_common_api.h \
- libretro-common/include/compat/fopen_utf8.h

--- a/mednafen/mednafen-types.h
+++ b/mednafen/mednafen-types.h
@@ -25,6 +25,7 @@ typedef uint64_t uint64;
 #define MDFN_LIKELY(n) __builtin_expect((n) != 0, 1)
 
   #define NO_INLINE __attribute__((noinline))
+  #define FORCE_INLINE inline __attribute__((always_inline))
 
   #if defined(__386__) || defined(__i386__) || defined(__i386) || defined(_M_IX86) || defined(_M_I386)
     #define MDFN_FASTCALL __attribute__((fastcall))
@@ -39,6 +40,8 @@ typedef uint64_t uint64;
 
 #elif defined(_MSC_VER)
   #define NO_INLINE
+  #define FORCE_INLINE __forceinline
+
 #define MDFN_LIKELY(n) ((n) != 0)
 #define MDFN_UNLIKELY(n) ((n) != 0)
 
@@ -55,6 +58,7 @@ typedef uint64_t uint64;
 #else
   #error "Not compiling with GCC nor MSVC"
   #define NO_INLINE
+  #define FORCE_INLINE inline
 
   #define MDFN_FASTCALL
 

--- a/mednafen/ss/scsp.h
+++ b/mednafen/ss/scsp.h
@@ -261,10 +261,48 @@ class SS_SCSP
  uint8 RBP;
  uint8 RBL;
  void RunDSP(void);
+ void DecodeMPROG(void);
+
+ struct DSPStep
+ {
+  uint8 IRA;	// 6 bits
+  uint8 IWA;	// 5 bits
+  uint8 EWA;	// 4 bits
+  uint8 MASA;	// 5 bits
+  uint8 CRA;	// 6 bits
+  uint8 TWA;	// 7 bits, MDEC_CT added at runtime
+  uint8 TRA;	// 7 bits, MDEC_CT added at runtime
+  uint8 YSEL;	// 2 bits
+  uint32 flags;	// see DSPF_* in scsp.inc
+  uint32 _reserved;	// hazard annotations (slice B)
+ };
+
+ enum
+ {
+  DSPF_NXADDR = 1u <<  0,
+  DSPF_ADRGB  = 1u <<  1,
+  DSPF_NOFL   = 1u <<  2,
+  DSPF_BSEL   = 1u <<  3,
+  DSPF_ZERO   = 1u <<  4,
+  DSPF_NEGB   = 1u <<  5,
+  DSPF_YRL    = 1u <<  6,
+  DSPF_SHFT0  = 1u <<  7,
+  DSPF_SHFT1  = 1u <<  8,
+  DSPF_FRCL   = 1u <<  9,
+  DSPF_ADRL   = 1u << 10,
+  DSPF_EWT    = 1u << 11,
+  DSPF_MRT    = 1u << 12,
+  DSPF_MWT    = 1u << 13,
+  DSPF_TABLE  = 1u << 14,
+  DSPF_IWT    = 1u << 15,
+  DSPF_XSEL   = 1u << 16,
+  DSPF_TWT    = 1u << 17
+ };
 
  struct DSPS
  {
   uint64 MPROG[0x80];
+  DSPStep MPROG_Decoded[0x80];
   uint32 TEMP[0x80];	// 24 bit
   uint32 MEMS[0x20];	// 24 bit
   uint16 COEF[64];	// 13 bit

--- a/mednafen/ss/scsp.h
+++ b/mednafen/ss/scsp.h
@@ -273,8 +273,11 @@ class SS_SCSP
   uint8 TWA;	// 7 bits, MDEC_CT added at runtime
   uint8 TRA;	// 7 bits, MDEC_CT added at runtime
   uint8 YSEL;	// 2 bits
-  uint32 flags;	// see DSPF_* in scsp.inc
-  uint32 _reserved;	// hazard annotations (slice B)
+  uint32 flags;	// see DSPF_*
+  uint8 hazard_next;	// bit 0: step N+1 RAW-depends on step N
+  uint8 reads;	// DSPR_* bitmask of carried state this step consumes
+  uint8 writes;	// DSPW_* bitmask of carried state this step produces
+  uint8 live;	// 0 = dead step, RunDSP skips it
  };
 
  enum
@@ -297,6 +300,27 @@ class SS_SCSP
   DSPF_IWT    = 1u << 15,
   DSPF_XSEL   = 1u << 16,
   DSPF_TWT    = 1u << 17
+ };
+
+ // Carried-state read/write bitmasks. Same bit positions for parallel R/W;
+ // distinct prefixes for clarity at use sites.
+ enum
+ {
+  DSPR_SFT  = 1u << 0,	// SFT_REG consumed (any of EWT/TWT/FRCL/ADRL/MWT or BSEL)
+  DSPR_FRC  = 1u << 1,	// FRC_REG consumed (YSEL == 0)
+  DSPR_Y    = 1u << 2,	// Y_REG consumed (YSEL == 2 or 3)
+  DSPR_ADRS = 1u << 3,	// ADRS_REG consumed (ADRGB)
+  DSPR_TEMP = 1u << 4,	// TEMP[TRA] value consumed (XSEL == 0 or BSEL == 0)
+  DSPR_MEMS = 1u << 5,	// MEMS[IRA] consumed ((IRA & 0x20) == 0)
+
+  DSPW_SFT   = 1u << 0,	// SFT_REG written (always)
+  DSPW_FRC   = 1u << 1,	// FRC_REG written (FRCL)
+  DSPW_Y     = 1u << 2,	// Y_REG written (YRL)
+  DSPW_ADRS  = 1u << 3,	// ADRS_REG written (ADRL)
+  DSPW_TEMP  = 1u << 4,	// TEMP[TWA] written (TWT)
+  DSPW_MEMS  = 1u << 5,	// MEMS[IWA] written (IWT)
+  DSPW_EFREG = 1u << 6,	// EFREG[EWA] written (EWT)
+  DSPW_RAM   = 1u << 7	// RAM pipeline state advanced (MRT or MWT)
  };
 
  struct DSPS

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -1206,7 +1206,71 @@ void SS_SCSP::DecodeMPROG(void)
   f |= ((instr >> 47) & 1) ? DSPF_XSEL   : 0;
   f |= ((instr >> 55) & 1) ? DSPF_TWT    : 0;
   s.flags = f;
-  s._reserved = 0;
+
+  uint8 reads = 0;
+  if(f & (DSPF_EWT | DSPF_TWT | DSPF_FRCL | DSPF_ADRL | DSPF_MWT | DSPF_BSEL))
+   reads |= DSPR_SFT;
+  if(s.YSEL == 0)                            reads |= DSPR_FRC;
+  if(s.YSEL == 2 || s.YSEL == 3)             reads |= DSPR_Y;
+  if(f & DSPF_ADRGB)                         reads |= DSPR_ADRS;
+  if(!(f & DSPF_XSEL) || !(f & DSPF_BSEL))   reads |= DSPR_TEMP;
+  if(!(s.IRA & 0x20))                        reads |= DSPR_MEMS;
+  s.reads = reads;
+
+  uint8 writes = DSPW_SFT;
+  if(f & DSPF_FRCL)                  writes |= DSPW_FRC;
+  if(f & DSPF_YRL)                   writes |= DSPW_Y;
+  if(f & DSPF_ADRL)                  writes |= DSPW_ADRS;
+  if(f & DSPF_TWT)                   writes |= DSPW_TEMP;
+  if(f & DSPF_IWT)                   writes |= DSPW_MEMS;
+  if(f & DSPF_EWT)                   writes |= DSPW_EFREG;
+  if(f & (DSPF_MRT | DSPF_MWT))      writes |= DSPW_RAM;
+  s.writes = writes;
+
+  s.hazard_next = 0;	// filled in by hazard pass
+  s.live = 1;		// filled in by liveness pass
+ }
+
+ // Hazard pass: hazard_next[N] bit 0 = "step N+1 RAW-depends on step N"
+ for(unsigned step = 0; step < 127; step++)
+ {
+  const DSPStep& cur = DSP.MPROG_Decoded[step];
+  const DSPStep& nxt = DSP.MPROG_Decoded[step + 1];
+  uint8 haz = 0;
+
+  if(nxt.reads & DSPR_SFT)                                         haz = 1;
+  else if((cur.writes & DSPW_FRC)  && (nxt.reads & DSPR_FRC))      haz = 1;
+  else if((cur.writes & DSPW_Y)    && (nxt.reads & DSPR_Y))        haz = 1;
+  else if((cur.writes & DSPW_ADRS) && (nxt.reads & DSPR_ADRS))     haz = 1;
+  else if((cur.writes & DSPW_TEMP) && (nxt.reads & DSPR_TEMP) && cur.TWA == nxt.TRA)
+                                                                   haz = 1;
+  else if((cur.writes & DSPW_MEMS) && (nxt.reads & DSPR_MEMS) && cur.IWA == (nxt.IRA & 0x1F))
+                                                                   haz = 1;
+  else if(cur.writes & DSPW_RAM)                                   haz = 1;
+
+  DSP.MPROG_Decoded[step].hazard_next = haz;
+ }
+
+ // Liveness pass: a step is dead if its only observable writes are SFT_REG and/or
+ // INPUTS, and the next step (wrapping for step 127 -> step 0 across the sample
+ // boundary) doesn't observe either of them.  INPUTS is preserved when IRA is in
+ // [0x32..0x3F]; otherwise the step writes INPUTS via MEMS/MIXS/EXTS.
+ for(unsigned step = 0; step < 128; step++)
+ {
+  const DSPStep& cur = DSP.MPROG_Decoded[step];
+  const DSPStep& nxt = DSP.MPROG_Decoded[(step + 1) & 0x7F];
+  const uint32 nf = nxt.flags;
+
+  const bool has_other_writes  = (cur.writes & ~(unsigned)DSPW_SFT) != 0;
+  const bool sft_observed      = (nxt.reads & DSPR_SFT) != 0;
+
+  const bool cur_writes_inputs    = !((cur.IRA & 0x30) == 0x30 && (cur.IRA & 0x0E) != 0);
+  const bool nxt_preserves_inputs =  ((nxt.IRA & 0x30) == 0x30 && (nxt.IRA & 0x0E) != 0);
+  const bool nxt_uses_inputs      = (nf & DSPF_YRL) || (nf & DSPF_XSEL) ||
+                                    ((nf & DSPF_ADRL) && !((nf & DSPF_SHFT0) && (nf & DSPF_SHFT1)));
+  const bool inputs_observed      = cur_writes_inputs && nxt_preserves_inputs && nxt_uses_inputs;
+
+  DSP.MPROG_Decoded[step].live = (has_other_writes || sft_observed || inputs_observed) ? 1 : 0;
  }
 
  DSP.MPROG_Dirty = false;
@@ -1220,6 +1284,7 @@ INLINE void SS_SCSP::RunDSP(void)
  for(unsigned step = 0; step < 128; step++)
  {
   const DSPStep& s = DSP.MPROG_Decoded[step];
+  if(!s.live) continue;
   const uint32 f = s.flags;
   const unsigned IRA = s.IRA;
   const unsigned TEMPWriteAddr = (s.TWA + DSP.MDEC_CT) & 0x7F;

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -1670,15 +1670,26 @@ INLINE void SS_SCSP::RunSample(T_out* outlr)
    }
   }
 
-  if(!Slots[(GlobalCounter - 4) & 0x1F].StackWriteInhibit)
   {
-   SoundStack[(GlobalCounter - 4) & 0x3F] = SoundStackDelayer[3];
-  }
+   uint64 packed;
+   memcpy(&packed, SoundStackDelayer, sizeof(SoundStackDelayer));
 
-  SoundStackDelayer[3] = SoundStackDelayer[2];
-  SoundStackDelayer[2] = SoundStackDelayer[1];
-  SoundStackDelayer[1] = SoundStackDelayer[0];
-  SoundStackDelayer[0] = sample;
+   if(!Slots[(GlobalCounter - 4) & 0x1F].StackWriteInhibit)
+   {
+#ifdef MSB_FIRST
+    SoundStack[(GlobalCounter - 4) & 0x3F] = (uint16)packed;
+#else
+    SoundStack[(GlobalCounter - 4) & 0x3F] = (uint16)(packed >> 48);
+#endif
+   }
+
+#ifdef MSB_FIRST
+   packed = (packed >> 16) | ((uint64)(uint16)sample << 48);
+#else
+   packed = (packed << 16) | (uint16)sample;
+#endif
+   memcpy(SoundStackDelayer, &packed, sizeof(SoundStackDelayer));
+  }
   //
   //
   if(SlotMonitorWhich == slot)

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -1141,75 +1141,89 @@ static INLINE uint32 int_to_dspfloat(const uint32 inv)
  return ret;
 }
 
-INLINE void SS_SCSP::RunDSP(void)
+//
+// Instruction field order/width RE'ing notes:
+//
+// Bit     0: NXADDR
+// Bit     1: ADRGB
+// Bit   2-6: MASA
+// Bit     8: NOFL (disables floating-point conversion when =1, instead just shifting by 8); has effect with MRT=1 or MWT=1
+// Bit  9-14: CRA (Coefficient read address, input into Y_SEL)
+// Bit    16: BSEL
+// Bit    17: ZERO
+// Bit    18: NEGB (apparently no effect when ZERO=1)
+// Bit    19: YRL
+// Bit    20: SHFT0
+// Bit    21: SHFT1
+// Bit    22: FRCL
+// Bit    23: ADRL (latches A_SEL output into ADRS_REG)
+// Bit 24-27: EWA(EFREG write address)
+// Bit    28: EWT(EFREG write enable)
+// Bit    29: MRT  (Memory read trigger; to read: [MWR=1] [whatever instruction] [IWT=1]
+// Bit    30: MWT  (Memory write trigger)
+// Bit    31: TABLE
+// Bit 32-36: IWA (MEMS write address)
+// Bit    37: IWT (MEMS write trigger)
+// Bit 38-43: IRA (0x00-0x1F MEMS, 0x20-0x2F MIXS)
+// Bit 45-46: YSEL
+// Bit    47: XSEL
+// Bit 48-54: TWA(temp write address) Seems to be an offset added to a counter changed each sample.
+// Bit    55: TWT(temp write trigger)  WARNING: Setting this to 1 for all 128 steps apparently can cause a CPU to freeze up if it tries to read/write TEMP afterward.
+// Bit 56-62: TRA(temp read address)
+void SS_SCSP::DecodeMPROG(void)
 {
- //
- //
- // Instruction field order/width RE'ing notes:
- //
- // Bit     0: NXADDR
- // Bit     1: ADRGB
- // Bit   2-6: MASA
- // Bit     8: NOFL (disables floating-point conversion when =1, instead just shifting by 8); has effect with MRT=1 or MWT=1
- // Bit  9-14: CRA (Coefficient read address, input into Y_SEL)
- // Bit    16: BSEL
- // Bit    17: ZERO
- // Bit    18: NEGB (apparently no effect when ZERO=1)
- // Bit    19: YRL
- // Bit    20: SHFT0
- // Bit    21: SHFT1
- // Bit    22: FRCL
- // Bit    23: ADRL (latches A_SEL output into ADRS_REG)
- // Bit 24-27: EWA(EFREG write address)
- // Bit    28: EWT(EFREG write enable)
- // Bit    29: MRT  (Memory read trigger; to read: [MWR=1] [whatever instruction] [IWT=1]
- // Bit    30: MWT  (Memory write trigger)
- // Bit    31: TABLE
- // Bit 32-36: IWA (MEMS write address)
- // Bit    37: IWT (MEMS write trigger)
- // Bit 38-43: IRA (0x00-0x1F MEMS, 0x20-0x2F MIXS)
- // Bit 45-46: YSEL
- // Bit    47: XSEL
- // Bit 48-54: TWA(temp write address) Seems to be an offset added to a counter changed each sample.
- // Bit    55: TWT(temp write trigger)  WARNING: Setting this to 1 for all 128 steps apparently can cause a CPU to freeze up if it tries to read/write TEMP afterward.
- // Bit 56-62: TRA(temp read address) 
  for(unsigned step = 0; step < 128; step++)
  {
   const uint64 instr = DSP.MPROG[step];
+  DSPStep& s = DSP.MPROG_Decoded[step];
 
-/*
-  assert(!(instr & (1ULL << 7)));
-  assert(!(instr & (1ULL << 15)));
-  assert(!(instr & (1ULL << 44)));
-  assert(!(instr & (1ULL << 63)));
-*/
+  s.MASA = (instr >>  2) & 0x1F;
+  s.CRA  = (instr >>  9) & 0x3F;
+  s.EWA  = (instr >> 24) & 0x0F;
+  s.IWA  = (instr >> 32) & 0x1F;
+  s.IRA  = (instr >> 38) & 0x3F;
+  s.YSEL = (instr >> 45) & 0x03;
+  s.TWA  = (instr >> 48) & 0x7F;
+  s.TRA  = (instr >> 56) & 0x7F;
 
-  const bool NXADDR = (instr >> 0) & 1;
-  const bool ADRGB = (instr >> 1) & 1;
-  const unsigned MASA = (instr >> 2) & 0x1F;
-  const bool NOFL = (instr >> 8) & 1;
-  const unsigned CRA = (instr >> 9) & 0x3F;
-  const bool BSEL = (instr >> 16) & 1;
-  const bool ZERO = (instr >> 17) & 1;
-  const bool NEGB = (instr >> 18) & 1;
-  const bool YRL = (instr >> 19) & 1;
-  const bool SHFT0 = (instr >> 20) & 1;
-  const bool SHFT1 = (instr >> 21) & 1;
-  const bool FRCL = (instr >> 22) & 1;  
-  const bool ADRL = (instr >> 23) & 1;
-  const unsigned EWA = (instr >> 24) & 0x0F;
-  const bool EWT = (instr >> 28) & 1;
-  const bool MRT = (instr >> 29) & 1;
-  const bool MWT = (instr >> 30) & 1;
-  const bool TABLE = (instr >> 31) & 1;
-  const unsigned IWA = (instr >> 32) & 0x1F;
-  const bool IWT = (instr >> 37) & 1;
-  const unsigned IRA = (instr >> 38) & 0x3F;
-  const unsigned YSEL = (instr >> 45) & 0x03;
-  const bool XSEL = (instr >> 47) & 1;
-  const unsigned TEMPWriteAddr = ((instr >> 48) + DSP.MDEC_CT) & 0x7F;
-  const bool TWT = (instr >> 55) & 1;
-  const unsigned TEMPReadAddr = ((instr >> 56) + DSP.MDEC_CT) & 0x7F;
+  uint32 f = 0;
+  f |= ((instr >>  0) & 1) ? DSPF_NXADDR : 0;
+  f |= ((instr >>  1) & 1) ? DSPF_ADRGB  : 0;
+  f |= ((instr >>  8) & 1) ? DSPF_NOFL   : 0;
+  f |= ((instr >> 16) & 1) ? DSPF_BSEL   : 0;
+  f |= ((instr >> 17) & 1) ? DSPF_ZERO   : 0;
+  f |= ((instr >> 18) & 1) ? DSPF_NEGB   : 0;
+  f |= ((instr >> 19) & 1) ? DSPF_YRL    : 0;
+  f |= ((instr >> 20) & 1) ? DSPF_SHFT0  : 0;
+  f |= ((instr >> 21) & 1) ? DSPF_SHFT1  : 0;
+  f |= ((instr >> 22) & 1) ? DSPF_FRCL   : 0;
+  f |= ((instr >> 23) & 1) ? DSPF_ADRL   : 0;
+  f |= ((instr >> 28) & 1) ? DSPF_EWT    : 0;
+  f |= ((instr >> 29) & 1) ? DSPF_MRT    : 0;
+  f |= ((instr >> 30) & 1) ? DSPF_MWT    : 0;
+  f |= ((instr >> 31) & 1) ? DSPF_TABLE  : 0;
+  f |= ((instr >> 37) & 1) ? DSPF_IWT    : 0;
+  f |= ((instr >> 47) & 1) ? DSPF_XSEL   : 0;
+  f |= ((instr >> 55) & 1) ? DSPF_TWT    : 0;
+  s.flags = f;
+  s._reserved = 0;
+ }
+
+ DSP.MPROG_Dirty = false;
+}
+
+INLINE void SS_SCSP::RunDSP(void)
+{
+ if(DSP.MPROG_Dirty)
+  DecodeMPROG();
+
+ for(unsigned step = 0; step < 128; step++)
+ {
+  const DSPStep& s = DSP.MPROG_Decoded[step];
+  const uint32 f = s.flags;
+  const unsigned IRA = s.IRA;
+  const unsigned TEMPWriteAddr = (s.TWA + DSP.MDEC_CT) & 0x7F;
+  const unsigned TEMPReadAddr  = (s.TRA + DSP.MDEC_CT) & 0x7F;
 
   //
   //
@@ -1231,20 +1245,22 @@ INLINE void SS_SCSP::RunDSP(void)
   }
 
   const int32 INPUTS = sign_x_to_s32(24, DSP.INPUTS);
-  const uint16 Y_SEL_Inputs[4] = { DSP.FRC_REG, DSP.COEF[CRA], (uint16)((DSP.Y_REG >> 11) & 0x1FFF), (uint16)((DSP.Y_REG >> 4) & 0x0FFF) };
+  const uint16 Y_SEL_Inputs[4] = { DSP.FRC_REG, DSP.COEF[s.CRA], (uint16)((DSP.Y_REG >> 11) & 0x1FFF), (uint16)((DSP.Y_REG >> 4) & 0x0FFF) };
   //
   //
   //
-  if(YRL)
+  if(f & DSPF_YRL)
   {
    DSP.Y_REG = INPUTS & 0xFFFFFF;
   }
   //
   //
   //
-  int32 ShifterOutput = (uint32)sign_x_to_s32(26, DSP.SFT_REG) << (SHFT0 ^ SHFT1);
+  const unsigned shft0 = (f >> 7) & 1;
+  const unsigned shft1 = (f >> 8) & 1;
+  int32 ShifterOutput = (uint32)sign_x_to_s32(26, DSP.SFT_REG) << (shft0 ^ shft1);
 
-  if(!SHFT1)
+  if(!shft1)
   {
    if(ShifterOutput > 0x7FFFFF)
     ShifterOutput = 0x7FFFFF;
@@ -1254,11 +1270,11 @@ INLINE void SS_SCSP::RunDSP(void)
   ShifterOutput &= 0xFFFFFF;
   //
   //
-  if(FRCL)
+  if(f & DSPF_FRCL)
   {
    const unsigned F_SEL_Inputs[2] = { (unsigned)(ShifterOutput >> 11), (unsigned)(ShifterOutput & 0xFFF) };
 
-   DSP.FRC_REG = F_SEL_Inputs[SHFT0 & SHFT1];
+   DSP.FRC_REG = F_SEL_Inputs[shft0 & shft1];
   }
   //
   //
@@ -1266,30 +1282,30 @@ INLINE void SS_SCSP::RunDSP(void)
    const int32 TEMP = sign_x_to_s32(24, DSP.TEMP[TEMPReadAddr]);
    const uint32 SGA_Inputs[2] = { (uint32)TEMP, DSP.SFT_REG };
    const int32 X_SEL_Inputs[2] = { TEMP, INPUTS };
-   const uint32 Product = ((int64)sign_x_to_s32(13, Y_SEL_Inputs[YSEL]) * X_SEL_Inputs[XSEL]) >> 12;
+   const uint32 Product = ((int64)sign_x_to_s32(13, Y_SEL_Inputs[s.YSEL]) * X_SEL_Inputs[(f >> 16) & 1]) >> 12;
    uint32 SGAOutput;
 
-   SGAOutput = SGA_Inputs[BSEL];
+   SGAOutput = SGA_Inputs[(f >> 3) & 1];
 
-   if(NEGB)
+   if(f & DSPF_NEGB)
     SGAOutput = -SGAOutput;
 
-   if(ZERO)
+   if(f & DSPF_ZERO)
     SGAOutput = 0;
 
    DSP.SFT_REG = (Product + SGAOutput) & 0x3FFFFFF;
   }
   //
   //
-  if(EWT)
-   DSP.EFREG[EWA] = (ShifterOutput >> 8);
+  if(f & DSPF_EWT)
+   DSP.EFREG[s.EWA] = (ShifterOutput >> 8);
 
-  if(TWT)
+  if(f & DSPF_TWT)
    DSP.TEMP[TEMPWriteAddr] = ShifterOutput;
 
-  if(IWT)
+  if(f & DSPF_IWT)
   {
-   DSP.MEMS[IWA] = DSP.ReadValue;
+   DSP.MEMS[s.IWA] = DSP.ReadValue;
   }
   //
   //
@@ -1310,15 +1326,15 @@ INLINE void SS_SCSP::RunDSP(void)
   {
    uint16 addr;
 
-   addr = DSP.MADRS[MASA];
-   addr += NXADDR;
+   addr = DSP.MADRS[s.MASA];
+   addr += (f & DSPF_NXADDR) ? 1 : 0;
 
-   if(ADRGB)
+   if(f & DSPF_ADRGB)
    {
     addr += sign_x_to_s32(12, DSP.ADRS_REG);
    }
 
-   if(!TABLE)
+   if(!(f & DSPF_TABLE))
    {
     addr += DSP.MDEC_CT;
     addr &= (0x2000 << RBL) - 1;
@@ -1326,23 +1342,23 @@ INLINE void SS_SCSP::RunDSP(void)
 
    DSP.RWAddr = (addr + (RBP << 12)) & 0x7FFFF;
 
-   if(MRT)
+   if(f & DSPF_MRT)
    {
-    DSP.ReadPending = 1 + NOFL;
+    DSP.ReadPending = (f & DSPF_NOFL) ? 2 : 1;
    }
-   if(MWT)
+   if(f & DSPF_MWT)
    {
     DSP.WritePending = true;
-    DSP.WriteValue = NOFL ? (ShifterOutput >> 8) : int_to_dspfloat(ShifterOutput);
+    DSP.WriteValue = (f & DSPF_NOFL) ? (ShifterOutput >> 8) : int_to_dspfloat(ShifterOutput);
    }
   }
   //
   //
-  if(ADRL)
+  if(f & DSPF_ADRL)
   {
    const uint16 A_SEL_Inputs[2] = { /*INPUTS is sign-extended above */ (uint16)((INPUTS >> 16) & 0xFFF), (uint16)(ShifterOutput >> 12) };
 
-   DSP.ADRS_REG = A_SEL_Inputs[SHFT0 & SHFT1];
+   DSP.ADRS_REG = A_SEL_Inputs[shft0 & shft1];
   }
  }
 

--- a/mednafen/ss/scu.inc
+++ b/mednafen/ss/scu.inc
@@ -1644,11 +1644,11 @@ sscpu_timestamp_t SCU_UpdateDSP(sscpu_timestamp_t timestamp)
 
  {
   DSPS* const dsp = &DSP;
-  while(MDFN_LIKELY(dsp->CycleCounter > 0))
-  {
+  // Threaded dispatch: the first handler tail-chains through the
+  // remaining cycles via DSP_TailDispatch and only returns once the
+  // budget is exhausted (or the DSP stopped).
+  if(MDFN_LIKELY(dsp->CycleCounter > 0))
    ((void (*)(DSPS*))(DSP_INSTR_BASE_UIPT + (uintptr_t)(DSP_INSTR_RECOVER_TCAST)dsp->NextInstr))(dsp);
-   dsp->CycleCounter -= 2;
-  }
  }
 
  if(MDFN_UNLIKELY(!DSP.IsRunning()))
@@ -1753,6 +1753,10 @@ static NO_INLINE NO_CLONE void DMAInstr(DSPS* dsp)
  else
   count = instr & 0xFF;
 
+ // do { } while(0) lets bus-error paths "break" out so we still
+ // fall through to DSP_TailDispatch at the end (the original
+ // dispatcher would re-enter on the next loop iteration).
+ do {
  if(dir)
  {
   const uint32 addr_add_amount = (1 << add_mode) &~ 1;
@@ -1761,7 +1765,7 @@ static NO_INLINE NO_CLONE void DMAInstr(DSPS* dsp)
 
   if(MDFN_UNLIKELY(WriteBus == -1))
   {
-   return;
+   break;
   }
 
   // Read from data RAM, write to external bus
@@ -1816,7 +1820,7 @@ static NO_INLINE NO_CLONE void DMAInstr(DSPS* dsp)
 
   if(MDFN_UNLIKELY(ReadBus == -1))
   {
-   return;
+   break;
   }
 
   dsp->PRAMDMABufCount = 0;
@@ -1869,6 +1873,9 @@ static NO_INLINE NO_CLONE void DMAInstr(DSPS* dsp)
   if(!hold)
    dsp->RAO = addr >> 2;
  }
+ } while(0);
+
+ DSP_TailDispatch(dsp);
 }
 
 MDFN_HIDE extern void (*const DSP_DMAFuncTable[2][8][8])(DSPS*) =

--- a/mednafen/ss/scu.inc
+++ b/mednafen/ss/scu.inc
@@ -1768,6 +1768,47 @@ static NO_INLINE NO_CLONE void DMAInstr(DSPS* dsp)
    break;
   }
 
+  // Fast path: a contiguous run of 16-bit writes landing entirely within the
+  // VDP2 register/RAM window. Collapse the per-halfword renderer-queue pushes
+  // (the hot part of DSP DMA) into a single burst command; the SH2-side array
+  // writes and their VRAM-bank access penalties still happen per halfword.
+  {
+   const unsigned words = count ? count : 256;
+   const unsigned n16 = words << 1;
+
+   if(WriteBus == 1 && addr >= 0x05E00000 &&
+      (uint64)addr + (uint64)(n16 - 1) * addr_add_amount <= 0x05FBFFFF)
+   {
+    uint16 burstbuf[512];
+    unsigned k = 0;
+
+    do
+    {
+     uint32 DB;
+
+     if(drw & 0x4)
+      DB = 0xFFFFFFFF;
+     else
+     {
+      DB = dsp->DataRAM[drw][dsp->CT[drw]];
+      dsp->CT[drw] = (dsp->CT[drw] + 1) & 0x3F;
+     }
+
+     burstbuf[k++] = DB >> 16;
+     burstbuf[k++] = DB & 0xFFFF;
+    } while(--count);
+
+    dsp->T0_Until -= (int32)n16;
+    dsp->T0_Until -= (int32)VDP2::Write16Burst_DB(addr, n16, add_mode, burstbuf);
+    addr += n16 * addr_add_amount;
+
+    if(!hold)
+     dsp->WAO = (addr + 2) >> 2;
+
+    break;
+   }
+  }
+
   // Read from data RAM, write to external bus
   do
   {

--- a/mednafen/ss/scu.inc
+++ b/mednafen/ss/scu.inc
@@ -641,7 +641,7 @@ static INLINE void SCU_RegRW_DB(uint32 A, uint32* DB)
 	 {
 	  if(DSP.State == 0)
 	  {
-	   ((void (*)(void))(DSP_INSTR_BASE_UIPT + (uintptr_t)(DSP_INSTR_RECOVER_TCAST)DSP.NextInstr))();
+	   ((void (*)(DSPS*))(DSP_INSTR_BASE_UIPT + (uintptr_t)(DSP_INSTR_RECOVER_TCAST)DSP.NextInstr))(&DSP);
 	   if(DSP.CycleCounter < -(DSP_EndCCSubVal / 2))	// Ugh
 	    DSP.CycleCounter += DSP_EndCCSubVal;
 	  }
@@ -1642,10 +1642,13 @@ sscpu_timestamp_t SCU_UpdateDSP(sscpu_timestamp_t timestamp)
  if(MDFN_UNLIKELY(!DSP.IsRunning()))
   return SS_EVENT_DISABLED_TS;
 
- while(MDFN_LIKELY(DSP.CycleCounter > 0))
  {
-  ((void (*)(void))(DSP_INSTR_BASE_UIPT + (uintptr_t)(DSP_INSTR_RECOVER_TCAST)DSP.NextInstr))();
-  DSP.CycleCounter -= 2;
+  DSPS* const dsp = &DSP;
+  while(MDFN_LIKELY(dsp->CycleCounter > 0))
+  {
+   ((void (*)(DSPS*))(DSP_INSTR_BASE_UIPT + (uintptr_t)(DSP_INSTR_RECOVER_TCAST)dsp->NextInstr))(dsp);
+   dsp->CycleCounter -= 2;
+  }
  }
 
  if(MDFN_UNLIKELY(!DSP.IsRunning()))
@@ -1724,28 +1727,28 @@ void DSP_FinishPRAMDMA(void)
 }
 
 template<bool looped, bool hold, bool format, bool dir, unsigned drw>
-static NO_INLINE NO_CLONE void DMAInstr(void)
+static NO_INLINE NO_CLONE void DMAInstr(DSPS* dsp)
 {
- const uint32 instr = DSP_InstrPre<looped>();
+ const uint32 instr = DSP_InstrPre<looped>(dsp);
  const unsigned add_mode = (instr >> 15) & 0x7;
  uint8 count;	// 0 = 256
 
- if(DSP.T0_Until < DSP.CycleCounter)
+ if(dsp->T0_Until < dsp->CycleCounter)
  {
   // TODO: Rework how DSP DMA is handled if this condition occurs with the same data RAM bank in any games.
 
-  DSP.CycleCounter = DSP.T0_Until &~ 1;
+  dsp->CycleCounter = dsp->T0_Until &~ 1;
  }
 
- DSP.T0_Until = DSP.CycleCounter;
+ dsp->T0_Until = dsp->CycleCounter;
 
  if(format)
  {
   const unsigned crw = instr & 0x3;
   const bool ctinc = instr & 0x4;
 
-  count = DSP.DataRAM[crw][DSP.CT[crw]] & 0xFF;
-  DSP.CT[crw] = (DSP.CT[crw] + ctinc) & 0x3F;
+  count = dsp->DataRAM[crw][dsp->CT[crw]] & 0xFF;
+  dsp->CT[crw] = (dsp->CT[crw] + ctinc) & 0x3F;
  }
  else
   count = instr & 0xFF;
@@ -1753,7 +1756,7 @@ static NO_INLINE NO_CLONE void DMAInstr(void)
  if(dir)
  {
   const uint32 addr_add_amount = (1 << add_mode) &~ 1;
-  uint32 addr = (DSP.WAO << 2) & 0x07FFFFFF;
+  uint32 addr = (dsp->WAO << 2) & 0x07FFFFFF;
   const int WriteBus = AddressToBus(addr);
 
   if(MDFN_UNLIKELY(WriteBus == -1))
@@ -1770,45 +1773,45 @@ static NO_INLINE NO_CLONE void DMAInstr(void)
     DB = 0xFFFFFFFF;
    else
    {
-    DB = DSP.DataRAM[drw][DSP.CT[drw]];
-    DSP.CT[drw] = (DSP.CT[drw] + 1) & 0x3F;
+    DB = dsp->DataRAM[drw][dsp->CT[drw]];
+    dsp->CT[drw] = (dsp->CT[drw] + 1) & 0x3F;
    }
 
    if(WriteBus == 2)
    {
     ne16_wbo_be<uint32>(WorkRAMH, addr & 0xFFFFC, DB);
     addr += addr_add_amount;
-    DSP.T0_Until -= 2;
+    dsp->T0_Until -= 2;
    }
    else if(WriteBus == 1)
    {
     uint16 DB16;
 
     DB16 = DB >> 16;
-    BBusRW_DB<uint16, true>(addr, &DB16, NULL, &DSP.T0_Until);
+    BBusRW_DB<uint16, true>(addr, &DB16, NULL, &dsp->T0_Until);
 
     addr += addr_add_amount;
 
     DB16 = DB;
-    BBusRW_DB<uint16, true, true>(addr, &DB16, NULL, &DSP.T0_Until);
+    BBusRW_DB<uint16, true, true>(addr, &DB16, NULL, &dsp->T0_Until);
 
     addr += addr_add_amount;
    }
    else if(WriteBus == 0)
    {
-    ABus_Write_DB32<uint32>(addr, DB, NULL, &DSP.T0_Until);
+    ABus_Write_DB32<uint32>(addr, DB, NULL, &dsp->T0_Until);
 
     addr += addr_add_amount;
    }
   } while(--count);
 
   if(!hold)
-   DSP.WAO = (addr + 2) >> 2;
+   dsp->WAO = (addr + 2) >> 2;
  }
  else
  {
   const uint32 addr_add_amount = (1 << (add_mode & 0x2)) &~ 1;
-  uint32 addr = (DSP.RAO << 2) & 0x07FFFFFF;
+  uint32 addr = (dsp->RAO << 2) & 0x07FFFFFF;
   const int ReadBus = AddressToBus(addr);
 
   if(MDFN_UNLIKELY(ReadBus == -1))
@@ -1816,7 +1819,7 @@ static NO_INLINE NO_CLONE void DMAInstr(void)
    return;
   }
 
-  DSP.PRAMDMABufCount = 0;
+  dsp->PRAMDMABufCount = 0;
 
   // Read from external bus, write to data RAM or program RAM
   do
@@ -1826,7 +1829,7 @@ static NO_INLINE NO_CLONE void DMAInstr(void)
    if(ReadBus == 2)
    {
     DB = ne16_rbo_be<uint32>(WorkRAMH, addr & 0xFFFFF);
-    DSP.T0_Until -= 2;
+    dsp->T0_Until -= 2;
 
     addr += addr_add_amount;
    }
@@ -1834,17 +1837,17 @@ static NO_INLINE NO_CLONE void DMAInstr(void)
    {
     uint16 tmp = 0;
 
-    BBusRW_DB<uint16, false>(addr | 0, &tmp, NULL, &DSP.T0_Until);
+    BBusRW_DB<uint16, false>(addr | 0, &tmp, NULL, &dsp->T0_Until);
     DB = tmp << 16;
 
-    BBusRW_DB<uint16, false, true>(addr | 2, &tmp, NULL, &DSP.T0_Until);
+    BBusRW_DB<uint16, false, true>(addr | 2, &tmp, NULL, &dsp->T0_Until);
     DB |= tmp << 0;
 
     addr += 4;
    }
    else if(ReadBus == 0)
    {
-    DB = ABus_Read(addr, NULL, &DSP.T0_Until);
+    DB = ABus_Read(addr, NULL, &dsp->T0_Until);
 
     addr += addr_add_amount;
    }
@@ -1853,22 +1856,22 @@ static NO_INLINE NO_CLONE void DMAInstr(void)
    {
     if(!(drw & 0x3))
     {
-     DSP.PRAMDMABuf[DSP.PRAMDMABufCount++ & 0xFF] = DB;
+     dsp->PRAMDMABuf[dsp->PRAMDMABufCount++ & 0xFF] = DB;
     }
    }
    else
    {
-    DSP.DataRAM[drw][DSP.CT[drw]] = DB;
-    DSP.CT[drw] = (DSP.CT[drw] + 1) & 0x3F;
+    dsp->DataRAM[drw][dsp->CT[drw]] = DB;
+    dsp->CT[drw] = (dsp->CT[drw] + 1) & 0x3F;
    }
   } while(--count);
 
   if(!hold)
-   DSP.RAO = addr >> 2;
+   dsp->RAO = addr >> 2;
  }
 }
 
-MDFN_HIDE extern void (*const DSP_DMAFuncTable[2][8][8])(void) =
+MDFN_HIDE extern void (*const DSP_DMAFuncTable[2][8][8])(DSPS*) =
 {
  #include "scu_dsp_dmatab.inc"
 };

--- a/mednafen/ss/scu_dsp_common.inc
+++ b/mednafen/ss/scu_dsp_common.inc
@@ -70,7 +70,7 @@ struct DSPS
  };
  int32 State;
 
- INLINE bool IsRunning(void)	// returns true if not stopped and not paused.
+ FORCE_INLINE bool IsRunning(void)	// returns true if not stopped and not paused.
  {
   return State > 0;
  }
@@ -152,7 +152,7 @@ MDFN_HIDE extern void (*const DSP_MiscFuncTable[2][4])(void);
 MDFN_HIDE extern DSPS DSP;
 
 template<bool looped = false>
-static INLINE uint64 DSP_DecodeInstruction(const uint32 instr)
+static FORCE_INLINE uint64 DSP_DecodeInstruction(const uint32 instr)
 {
  void (*aal)(void);
 
@@ -194,7 +194,7 @@ static INLINE uint64 DSP_DecodeInstruction(const uint32 instr)
 }
 
 template<bool looped>
-static INLINE uint32 DSP_InstrPre(void)
+static FORCE_INLINE uint32 DSP_InstrPre(void)
 {
  const uint32 instr = DSP.NextInstr >> 32;
 
@@ -211,7 +211,7 @@ static INLINE uint32 DSP_InstrPre(void)
 }
 
 template<unsigned cond>
-static INLINE bool DSP_TestCond(void)
+static FORCE_INLINE bool DSP_TestCond(void)
 {
  if(!(cond & 0x40))
   return true;

--- a/mednafen/ss/scu_dsp_common.inc
+++ b/mednafen/ss/scu_dsp_common.inc
@@ -210,6 +210,28 @@ static FORCE_INLINE uint32 DSP_InstrPre(DSPS* dsp)
  return instr;
 }
 
+//
+// At the tail of every handler: account for this instruction's cycle
+// cost, decide whether the dispatcher should keep running, and call
+// the next handler.  The next handler's pointer was already prefetched
+// into dsp->NextInstr by DSP_InstrPre at the top of this handler.
+//
+// SCU_UpdateDSP caps CycleCounter at DSP_UpdateTimingGran (=64) on
+// entry, and the DMA / END paths can only lower it -- so the chain is
+// bounded to ~32 calls.  Modern optimizing compilers turn the call
+// below into a tail jump (verified on GCC 15 / -O2 / aarch64); even
+// when they don't, the bounded depth keeps the stack safe.
+//
+static FORCE_INLINE void DSP_TailDispatch(DSPS* dsp)
+{
+ dsp->CycleCounter -= 2;
+ if(MDFN_UNLIKELY(dsp->CycleCounter <= 0 || !dsp->IsRunning()))
+  return;
+
+ void (* const next)(DSPS*) = (void (*)(DSPS*))(DSP_INSTR_BASE_UIPT + (uintptr_t)(DSP_INSTR_RECOVER_TCAST)dsp->NextInstr);
+ next(dsp);
+}
+
 template<unsigned cond>
 static FORCE_INLINE bool DSP_TestCond(DSPS* dsp)
 {

--- a/mednafen/ss/scu_dsp_common.inc
+++ b/mednafen/ss/scu_dsp_common.inc
@@ -121,7 +121,7 @@ struct DSPS
 //   X Op: bits 23-25	- * 8
 //   Y Op: bits 17-19	- * 8
 //  D1 Op: bits 12-13	- * 4
-MDFN_HIDE extern void (*const DSP_GenFuncTable[2][16][8][8][4])(void);
+MDFN_HIDE extern void (*const DSP_GenFuncTable[2][16][8][8][4])(DSPS*);
 
 // Hold/Format/Direction: bits 12-14
 //  Hold: bit 14
@@ -129,32 +129,32 @@ MDFN_HIDE extern void (*const DSP_GenFuncTable[2][16][8][8][4])(void);
 //  Direction: bit 12
 // RAM: bits 8-10
 //
-MDFN_HIDE extern void (*const DSP_DMAFuncTable[2][8][8])(void);
+MDFN_HIDE extern void (*const DSP_DMAFuncTable[2][8][8])(DSPS*);
 
 //
 // Dest: bits 26-29
 // Condition: bits 19-25
 //
-MDFN_HIDE extern void (*const DSP_MVIFuncTable[2][16][128])(void);
+MDFN_HIDE extern void (*const DSP_MVIFuncTable[2][16][128])(DSPS*);
 
 //
 // Condition: bits 19-25
 //
-MDFN_HIDE extern void (*const DSP_JMPFuncTable[2][128])(void);
+MDFN_HIDE extern void (*const DSP_JMPFuncTable[2][128])(DSPS*);
 
 
 //
 // LPS, BTM, END, ENDI(bits 29-31 = 0x7)
 // bits 27-28
 //
-MDFN_HIDE extern void (*const DSP_MiscFuncTable[2][4])(void);
+MDFN_HIDE extern void (*const DSP_MiscFuncTable[2][4])(DSPS*);
 
 MDFN_HIDE extern DSPS DSP;
 
 template<bool looped = false>
 static FORCE_INLINE uint64 DSP_DecodeInstruction(const uint32 instr)
 {
- void (*aal)(void);
+ void (*aal)(DSPS*);
 
  switch((instr >> 28) & 0xF)
  {
@@ -194,24 +194,24 @@ static FORCE_INLINE uint64 DSP_DecodeInstruction(const uint32 instr)
 }
 
 template<bool looped>
-static FORCE_INLINE uint32 DSP_InstrPre(void)
+static FORCE_INLINE uint32 DSP_InstrPre(DSPS* dsp)
 {
- const uint32 instr = DSP.NextInstr >> 32;
+ const uint32 instr = dsp->NextInstr >> 32;
 
- if(!looped || !DSP.LOP)
+ if(!looped || !dsp->LOP)
  {
-  DSP.NextInstr = DSP.ProgRAM[DSP.PC];
-  DSP.PC++;
+  dsp->NextInstr = dsp->ProgRAM[dsp->PC];
+  dsp->PC++;
  }
 
  if(looped)
-  DSP.LOP = (DSP.LOP - 1) & 0x0FFF;
+  dsp->LOP = (dsp->LOP - 1) & 0x0FFF;
 
  return instr;
 }
 
 template<unsigned cond>
-static FORCE_INLINE bool DSP_TestCond(void)
+static FORCE_INLINE bool DSP_TestCond(DSPS* dsp)
 {
  if(!(cond & 0x40))
   return true;
@@ -221,16 +221,16 @@ static FORCE_INLINE bool DSP_TestCond(void)
  bool ret = false;
 
  if(cond & 0x1)
-  ret |= DSP.FlagZ;
+  ret |= dsp->FlagZ;
 
  if(cond & 0x2)
-  ret |= DSP.FlagS;
+  ret |= dsp->FlagS;
 
  if(cond & 0x4)
-  ret |= DSP.FlagC;
+  ret |= dsp->FlagC;
 
  if(cond & 0x8)
-  ret |= (DSP.T0_Until < DSP.CycleCounter);
+  ret |= (dsp->T0_Until < dsp->CycleCounter);
 
  //if(cond & 0x10)	// ?
 

--- a/mednafen/ss/scu_dsp_gen.cpp
+++ b/mednafen/ss/scu_dsp_gen.cpp
@@ -34,32 +34,32 @@
 
 #include "scu_dsp_common.inc"
 
-static FORCE_INLINE void SetC(bool value)
+static FORCE_INLINE void SetC(DSPS* dsp, bool value)
 {
- DSP.FlagC = value;
+ dsp->FlagC = value;
 }
 
-static FORCE_INLINE void CalcZS32(uint32 val)
+static FORCE_INLINE void CalcZS32(DSPS* dsp, uint32 val)
 {
- DSP.FlagS = (int32)val < 0;
- DSP.FlagZ = !val;
+ dsp->FlagS = (int32)val < 0;
+ dsp->FlagZ = !val;
 }
 
-static FORCE_INLINE void CalcZS48(uint64 val)
+static FORCE_INLINE void CalcZS48(DSPS* dsp, uint64 val)
 {
  val <<= 16;
 
- DSP.FlagS = (int64)val < 0;
- DSP.FlagZ = !val;
+ dsp->FlagS = (int64)val < 0;
+ dsp->FlagZ = !val;
 }
 
 
 template<const bool looped, const unsigned alu_op, const unsigned x_op, const unsigned y_op, const unsigned d1_op>
-static NO_INLINE NO_CLONE void GeneralInstr(void)
+static NO_INLINE NO_CLONE void GeneralInstr(DSPS* dsp)
 {
- const uint32 instr = DSP_InstrPre<looped>();
+ const uint32 instr = DSP_InstrPre<looped>(dsp);
  //
- DSPR48 ALU = DSP.AC;
+ DSPR48 ALU = dsp->AC;
  unsigned dr_read = 0;
  unsigned ct_inc = 0;
 
@@ -79,9 +79,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   //
   case 0x01:
   {
-   ALU.L &= DSP.P.L;
-   SetC(false);
-   CalcZS32(ALU.L);
+   ALU.L &= dsp->P.L;
+   SetC(dsp, false);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -90,9 +90,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   //
   case 0x02:
   {
-   ALU.L |= DSP.P.L;
-   SetC(false);
-   CalcZS32(ALU.L);
+   ALU.L |= dsp->P.L;
+   SetC(dsp, false);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -101,9 +101,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   //
   case 0x03:
   {
-   ALU.L ^= DSP.P.L;
-   SetC(false);
-   CalcZS32(ALU.L);
+   ALU.L ^= dsp->P.L;
+   SetC(dsp, false);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -112,11 +112,11 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   //
   case 0x04:
   {
-   const uint64 tmp = (uint64)ALU.L + DSP.P.L;
+   const uint64 tmp = (uint64)ALU.L + dsp->P.L;
 
-   DSP.FlagV |= (((~(ALU.L ^ DSP.P.L)) & (ALU.L ^ tmp)) >> 31) & 1;
-   SetC((tmp >> 32) & 0x1);
-   CalcZS32(tmp);
+   dsp->FlagV |= (((~(ALU.L ^ dsp->P.L)) & (ALU.L ^ tmp)) >> 31) & 1;
+   SetC(dsp, (tmp >> 32) & 0x1);
+   CalcZS32(dsp, tmp);
    ALU.L = tmp;
   }
   break;
@@ -126,11 +126,11 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   //
   case 0x05:
   {
-   const uint64 tmp = (uint64)ALU.L - DSP.P.L;
+   const uint64 tmp = (uint64)ALU.L - dsp->P.L;
 
-   DSP.FlagV |= ((((ALU.L ^ DSP.P.L)) & (ALU.L ^ tmp)) >> 31) & 1;
-   SetC((tmp >> 32) & 0x1);
-   CalcZS32(tmp);
+   dsp->FlagV |= ((((ALU.L ^ dsp->P.L)) & (ALU.L ^ tmp)) >> 31) & 1;
+   SetC(dsp, (tmp >> 32) & 0x1);
+   CalcZS32(dsp, tmp);
    ALU.L = tmp;
   }
   break;
@@ -140,11 +140,11 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   //
   case 0x06:
   {
-   const uint64 tmp = (ALU.T & 0xFFFFFFFFFFFFULL) + (DSP.P.T & 0xFFFFFFFFFFFFULL);
+   const uint64 tmp = (ALU.T & 0xFFFFFFFFFFFFULL) + (dsp->P.T & 0xFFFFFFFFFFFFULL);
 
-   DSP.FlagV |= (((~(ALU.T ^ DSP.P.T)) & (ALU.T ^ tmp)) >> 47) & 1;
-   SetC((tmp >> 48) & 0x1);
-   CalcZS48(tmp);
+   dsp->FlagV |= (((~(ALU.T ^ dsp->P.T)) & (ALU.T ^ tmp)) >> 47) & 1;
+   SetC(dsp, (tmp >> 48) & 0x1);
+   CalcZS48(dsp, tmp);
    ALU.T = tmp;
   }
   break;
@@ -156,9 +156,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   {
    const bool new_C = ALU.L & 0x1;
 
-   SetC(new_C);
+   SetC(dsp, new_C);
    ALU.L = (int32)ALU.L >> 1;
-   CalcZS32(ALU.L);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -169,9 +169,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   {
    const bool new_C = ALU.L & 0x1;
 
-   SetC(new_C);
+   SetC(dsp, new_C);
    ALU.L = (ALU.L >> 1) | (new_C << 31);
-   CalcZS32(ALU.L);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -182,9 +182,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   {
    const bool new_C = ALU.L >> 31;
 
-   SetC(new_C);
+   SetC(dsp, new_C);
    ALU.L <<= 1;
-   CalcZS32(ALU.L);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -195,9 +195,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   {
    const bool new_C = ALU.L >> 31;
 
-   SetC(new_C);
+   SetC(dsp, new_C);
    ALU.L = (ALU.L << 1) | new_C;
-   CalcZS32(ALU.L);
+   CalcZS32(dsp, ALU.L);
   }
   break;
 
@@ -208,9 +208,9 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   {
    const bool new_C = (ALU.L >> 24) & 1;
 
-   SetC(new_C);
+   SetC(dsp, new_C);
    ALU.L = (ALU.L << 8) | (ALU.L >> 24);
-   CalcZS32(ALU.L);
+   CalcZS32(dsp, ALU.L);
   }
   break;
  }
@@ -219,7 +219,7 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
  // X Op
  //
  if((x_op & 0x3) == 0x2)
-  DSP.P.T = (int64)(int32)DSP.RX * (int32)DSP.RY;
+  dsp->P.T = (int64)(int32)dsp->RX * (int32)dsp->RY;
 
  if(x_op >= 0x3)
  {
@@ -227,24 +227,24 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   const size_t drw = s & 0x3;
   uint32 src_data;
 
-  src_data = DSP.DataRAM[drw][DSP.CT[drw]];
+  src_data = dsp->DataRAM[drw][dsp->CT[drw]];
   dr_read |= 1U << drw;
   ct_inc |= (bool)(s & 0x4) << (drw << 3);
 
   if((x_op & 0x3) == 0x3)
-   DSP.P.T = (int32)src_data;
+   dsp->P.T = (int32)src_data;
 
   if(x_op & 0x4)
-   DSP.RX = src_data;
+   dsp->RX = src_data;
  }
 
  //
  // Y Op
  //
  if((y_op & 0x3) == 0x1)
-  DSP.AC.T = 0;
+  dsp->AC.T = 0;
  else if((y_op & 0x3) == 0x2)
-  DSP.AC.T = ALU.T;
+  dsp->AC.T = ALU.T;
 
  if(y_op >= 0x3)
  {
@@ -252,15 +252,15 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
   const size_t drw = s & 0x3;
   uint32 src_data;
 
-  src_data = DSP.DataRAM[drw][DSP.CT[drw]];
+  src_data = dsp->DataRAM[drw][dsp->CT[drw]];
   dr_read |= 1U << drw;
   ct_inc |= (bool)(s & 0x4) << (drw << 3);
 
   if((y_op & 0x3) == 0x3)
-   DSP.AC.T = (int32)src_data;
+   dsp->AC.T = (int32)src_data;
 
   if(y_op & 0x4)
-   DSP.RY = src_data;
+   dsp->RY = src_data;
  }
 
  //
@@ -282,15 +282,15 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
     case 0xE:
     case 0xF: src_data = 0xFFFFFFFF; break;
 
-    case 0x0: src_data = DSP.DataRAM[0][DSP.CT[0]]; dr_read |= 0x01; break;
-    case 0x1: src_data = DSP.DataRAM[1][DSP.CT[1]]; dr_read |= 0x02; break;
-    case 0x2: src_data = DSP.DataRAM[2][DSP.CT[2]]; dr_read |= 0x04; break;
-    case 0x3: src_data = DSP.DataRAM[3][DSP.CT[3]]; dr_read |= 0x08; break;
+    case 0x0: src_data = dsp->DataRAM[0][dsp->CT[0]]; dr_read |= 0x01; break;
+    case 0x1: src_data = dsp->DataRAM[1][dsp->CT[1]]; dr_read |= 0x02; break;
+    case 0x2: src_data = dsp->DataRAM[2][dsp->CT[2]]; dr_read |= 0x04; break;
+    case 0x3: src_data = dsp->DataRAM[3][dsp->CT[3]]; dr_read |= 0x08; break;
 
-    case 0x4: src_data = DSP.DataRAM[0][DSP.CT[0]]; if(d != 0) { ct_inc |= 1 <<  0; } dr_read |= 0x01; break;
-    case 0x5: src_data = DSP.DataRAM[1][DSP.CT[1]]; if(d != 1) { ct_inc |= 1 <<  8; } dr_read |= 0x02; break;
-    case 0x6: src_data = DSP.DataRAM[2][DSP.CT[2]]; if(d != 2) { ct_inc |= 1 << 16; } dr_read |= 0x04; break;
-    case 0x7: src_data = DSP.DataRAM[3][DSP.CT[3]]; if(d != 3) { ct_inc |= 1 << 24; } dr_read |= 0x08; break;
+    case 0x4: src_data = dsp->DataRAM[0][dsp->CT[0]]; if(d != 0) { ct_inc |= 1 <<  0; } dr_read |= 0x01; break;
+    case 0x5: src_data = dsp->DataRAM[1][dsp->CT[1]]; if(d != 1) { ct_inc |= 1 <<  8; } dr_read |= 0x02; break;
+    case 0x6: src_data = dsp->DataRAM[2][dsp->CT[2]]; if(d != 2) { ct_inc |= 1 << 16; } dr_read |= 0x04; break;
+    case 0x7: src_data = dsp->DataRAM[3][dsp->CT[3]]; if(d != 3) { ct_inc |= 1 << 24; } dr_read |= 0x08; break;
 
     case 0x9: src_data = ALU.T; break;
     case 0xA: src_data = ALU.T >> 16; break;
@@ -299,27 +299,27 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
 
   switch(d)
   {
-   case 0x0: if(!(dr_read & 0x01)) { DSP.DataRAM[0][DSP.CT[0]] = src_data; ct_inc |= 1 <<  0; } break;
-   case 0x1: if(!(dr_read & 0x02)) { DSP.DataRAM[1][DSP.CT[1]] = src_data; ct_inc |= 1 <<  8; } break;
-   case 0x2: if(!(dr_read & 0x04)) { DSP.DataRAM[2][DSP.CT[2]] = src_data; ct_inc |= 1 << 16; } break;
-   case 0x3: if(!(dr_read & 0x08)) { DSP.DataRAM[3][DSP.CT[3]] = src_data; ct_inc |= 1 << 24; } break;
-   case 0x4: DSP.RX = src_data; break;
-   case 0x5: DSP.P.T = (int32)src_data; break;
-   case 0x6: DSP.RAO = src_data; break;
-   case 0x7: DSP.WAO = src_data; break;
+   case 0x0: if(!(dr_read & 0x01)) { dsp->DataRAM[0][dsp->CT[0]] = src_data; ct_inc |= 1 <<  0; } break;
+   case 0x1: if(!(dr_read & 0x02)) { dsp->DataRAM[1][dsp->CT[1]] = src_data; ct_inc |= 1 <<  8; } break;
+   case 0x2: if(!(dr_read & 0x04)) { dsp->DataRAM[2][dsp->CT[2]] = src_data; ct_inc |= 1 << 16; } break;
+   case 0x3: if(!(dr_read & 0x08)) { dsp->DataRAM[3][dsp->CT[3]] = src_data; ct_inc |= 1 << 24; } break;
+   case 0x4: dsp->RX = src_data; break;
+   case 0x5: dsp->P.T = (int32)src_data; break;
+   case 0x6: dsp->RAO = src_data; break;
+   case 0x7: dsp->WAO = src_data; break;
    case 0x8:
    case 0x9: break;
-   case 0xA: if(!looped || DSP.LOP == 0x0FFF) { DSP.LOP = src_data & 0x0FFF; } break;
-   case 0xB: DSP.TOP = src_data & 0xFF; break;
+   case 0xA: if(!looped || dsp->LOP == 0x0FFF) { dsp->LOP = src_data & 0x0FFF; } break;
+   case 0xB: dsp->TOP = src_data & 0xFF; break;
 
    //
    // Don't bother masking with 0x3F here, since the & 0x3F3F3F3F mask down below will cover it(and no chance of overflowing into an adjacent byte
    // since we're masking out the corresponding byte in ct_inc, too).
    //
-   case 0xC: DSP.CT[0] = src_data; ct_inc &= ~0x000000FF; break;
-   case 0xD: DSP.CT[1] = src_data; ct_inc &= ~0x0000FF00; break;
-   case 0xE: DSP.CT[2] = src_data; ct_inc &= ~0x00FF0000; break;
-   case 0xF: DSP.CT[3] = src_data; ct_inc &= ~0xFF000000; break;
+   case 0xC: dsp->CT[0] = src_data; ct_inc &= ~0x000000FF; break;
+   case 0xD: dsp->CT[1] = src_data; ct_inc &= ~0x0000FF00; break;
+   case 0xE: dsp->CT[2] = src_data; ct_inc &= ~0x00FF0000; break;
+   case 0xF: dsp->CT[3] = src_data; ct_inc &= ~0xFF000000; break;
   }
  }
 
@@ -331,10 +331,10 @@ static NO_INLINE NO_CLONE void GeneralInstr(void)
  #endif
 
  if(x_op >= 0x3 || y_op >= 0x3 || (d1_op & 0x1))
-  DSP.CT32 = (DSP.CT32 + ct_inc) & 0x3F3F3F3F;
+  dsp->CT32 = (dsp->CT32 + ct_inc) & 0x3F3F3F3F;
 }
 
-MDFN_HIDE extern void (*const DSP_GenFuncTable[2][16][8][8][4])(void) =
+MDFN_HIDE extern void (*const DSP_GenFuncTable[2][16][8][8][4])(DSPS*) =
 {
  #include "scu_dsp_gentab.inc"
 };

--- a/mednafen/ss/scu_dsp_gen.cpp
+++ b/mednafen/ss/scu_dsp_gen.cpp
@@ -34,18 +34,18 @@
 
 #include "scu_dsp_common.inc"
 
-static INLINE void SetC(bool value)
+static FORCE_INLINE void SetC(bool value)
 {
  DSP.FlagC = value;
 }
 
-static INLINE void CalcZS32(uint32 val)
+static FORCE_INLINE void CalcZS32(uint32 val)
 {
  DSP.FlagS = (int32)val < 0;
  DSP.FlagZ = !val;
 }
 
-static INLINE void CalcZS48(uint64 val)
+static FORCE_INLINE void CalcZS48(uint64 val)
 {
  val <<= 16;
 

--- a/mednafen/ss/scu_dsp_gen.cpp
+++ b/mednafen/ss/scu_dsp_gen.cpp
@@ -332,6 +332,8 @@ static NO_INLINE NO_CLONE void GeneralInstr(DSPS* dsp)
 
  if(x_op >= 0x3 || y_op >= 0x3 || (d1_op & 0x1))
   dsp->CT32 = (dsp->CT32 + ct_inc) & 0x3F3F3F3F;
+
+ DSP_TailDispatch(dsp);
 }
 
 MDFN_HIDE extern void (*const DSP_GenFuncTable[2][16][8][8][4])(DSPS*) =

--- a/mednafen/ss/scu_dsp_jmp.cpp
+++ b/mednafen/ss/scu_dsp_jmp.cpp
@@ -33,6 +33,8 @@ static NO_INLINE NO_CLONE void JMPInstr(DSPS* dsp)
 
  if(DSP_TestCond<cond>(dsp))
   dsp->PC = (uint8)instr;
+
+ DSP_TailDispatch(dsp);
 }
 
 MDFN_HIDE extern void (*const DSP_JMPFuncTable[2][128])(DSPS*) =

--- a/mednafen/ss/scu_dsp_jmp.cpp
+++ b/mednafen/ss/scu_dsp_jmp.cpp
@@ -27,15 +27,15 @@
 #include "scu_dsp_common.inc"
 
 template<bool looped, unsigned cond>
-static NO_INLINE NO_CLONE void JMPInstr(void)
+static NO_INLINE NO_CLONE void JMPInstr(DSPS* dsp)
 {
- const uint32 instr = DSP_InstrPre<looped>();
+ const uint32 instr = DSP_InstrPre<looped>(dsp);
 
- if(DSP_TestCond<cond>())
-  DSP.PC = (uint8)instr;
+ if(DSP_TestCond<cond>(dsp))
+  dsp->PC = (uint8)instr;
 }
 
-MDFN_HIDE extern void (*const DSP_JMPFuncTable[2][128])(void) =
+MDFN_HIDE extern void (*const DSP_JMPFuncTable[2][128])(DSPS*) =
 {
  #include "scu_dsp_jmptab.inc"
 };

--- a/mednafen/ss/scu_dsp_misc.cpp
+++ b/mednafen/ss/scu_dsp_misc.cpp
@@ -59,6 +59,8 @@ static NO_INLINE NO_CLONE void MiscInstr(DSPS* dsp)
  {
   dsp->NextInstr = DSP_DecodeInstruction<true>(dsp->NextInstr >> 32);
  }
+
+ DSP_TailDispatch(dsp);
 }
 
 MDFN_HIDE extern void (*const DSP_MiscFuncTable[2][4])(DSPS*) =

--- a/mednafen/ss/scu_dsp_misc.cpp
+++ b/mednafen/ss/scu_dsp_misc.cpp
@@ -25,9 +25,9 @@
 #include "scu_dsp_common.inc"
 
 template<bool looped, unsigned op>
-static NO_INLINE NO_CLONE void MiscInstr(void)
+static NO_INLINE NO_CLONE void MiscInstr(DSPS* dsp)
 {
- DSP_InstrPre<looped>();
+ DSP_InstrPre<looped>(dsp);
 
  //
  // END/ENDI
@@ -36,32 +36,32 @@ static NO_INLINE NO_CLONE void MiscInstr(void)
  {
   if(op & 0x1)
   {
-   DSP.FlagEnd = true;
+   dsp->FlagEnd = true;
    SCU_SetInt(SCU_INT_DSP, true);
   }
 
-  if(DSP.PRAMDMABufCount)
+  if(dsp->PRAMDMABufCount)
    DSP_FinishPRAMDMA();
   else
   {
-   DSP.State &= ~DSPS::STATE_MASK_EXECUTE;
-   DSP.CycleCounter -= DSP_EndCCSubVal;	// Break out of execution loop(also remember to handle this case for manual stepping via port writes).
+   dsp->State &= ~DSPS::STATE_MASK_EXECUTE;
+   dsp->CycleCounter -= DSP_EndCCSubVal;	// Break out of execution loop(also remember to handle this case for manual stepping via port writes).
   }
  }
  else if(op == 0)	// BTM
  {
-  if(DSP.LOP)
-   DSP.PC = DSP.TOP;
+  if(dsp->LOP)
+   dsp->PC = dsp->TOP;
 
-  DSP.LOP = (DSP.LOP - 1) & 0x0FFF;
+  dsp->LOP = (dsp->LOP - 1) & 0x0FFF;
  }
  else if(op == 1)	// LPS
  {
-  DSP.NextInstr = DSP_DecodeInstruction<true>(DSP.NextInstr >> 32);
+  dsp->NextInstr = DSP_DecodeInstruction<true>(dsp->NextInstr >> 32);
  }
 }
 
-MDFN_HIDE extern void (*const DSP_MiscFuncTable[2][4])(void) =
+MDFN_HIDE extern void (*const DSP_MiscFuncTable[2][4])(DSPS*) =
 {
  #include "scu_dsp_misctab.inc"
 };

--- a/mednafen/ss/scu_dsp_mvi.cpp
+++ b/mednafen/ss/scu_dsp_mvi.cpp
@@ -75,6 +75,8 @@ static NO_INLINE NO_CLONE void MVIInstr(DSPS* dsp)
 	break;
   }
  }
+
+ DSP_TailDispatch(dsp);
 }
 
 

--- a/mednafen/ss/scu_dsp_mvi.cpp
+++ b/mednafen/ss/scu_dsp_mvi.cpp
@@ -25,9 +25,9 @@
 #include "scu_dsp_common.inc"
 
 template<bool looped, unsigned dest, unsigned cond>
-static NO_INLINE NO_CLONE void MVIInstr(void)
+static NO_INLINE NO_CLONE void MVIInstr(DSPS* dsp)
 {
- const uint32 instr = DSP_InstrPre<looped>();
+ const uint32 instr = DSP_InstrPre<looped>(dsp);
  uint32 imm;
 
  if(cond & 0x40)
@@ -35,11 +35,11 @@ static NO_INLINE NO_CLONE void MVIInstr(void)
  else
   imm = sign_x_to_s32(25, instr);
 
- if(DSP_TestCond<cond>())
+ if(DSP_TestCond<cond>(dsp))
  {
-  if(DSP.PRAMDMABufCount && (dest == 0x6 || dest == 0x7))
+  if(dsp->PRAMDMABufCount && (dest == 0x6 || dest == 0x7))
   {
-   DSP.PC--;
+   dsp->PC--;
    //
    DSP_FinishPRAMDMA();
   }
@@ -53,24 +53,24 @@ static NO_INLINE NO_CLONE void MVIInstr(void)
    case 0x1:
    case 0x2:
    case 0x3:
-	DSP.DataRAM[dest][DSP.CT[dest]] = imm;
-	DSP.CT[dest] = (DSP.CT[dest] + 1) & 0x3F;
+	dsp->DataRAM[dest][dsp->CT[dest]] = imm;
+	dsp->CT[dest] = (dsp->CT[dest] + 1) & 0x3F;
 	break;
 
-   case 0x4: DSP.RX = imm; break;
-   case 0x5: DSP.P.T = (int32)imm; break;
+   case 0x4: dsp->RX = imm; break;
+   case 0x5: dsp->P.T = (int32)imm; break;
 
-   case 0x6: DSP.RAO = imm; break;
+   case 0x6: dsp->RAO = imm; break;
 
-   case 0x7: DSP.WAO = imm; break;
- 
-   case 0xA: if(!looped || DSP.LOP == 0x0FFF) { DSP.LOP = imm & 0x0FFF; } break;
+   case 0x7: dsp->WAO = imm; break;
+
+   case 0xA: if(!looped || dsp->LOP == 0x0FFF) { dsp->LOP = imm & 0x0FFF; } break;
 
    case 0xC:
-	DSP.TOP = DSP.PC - 1;
-	DSP.PC = imm & 0xFF;
+	dsp->TOP = dsp->PC - 1;
+	dsp->PC = imm & 0xFF;
         //
-	if(DSP.PRAMDMABufCount)
+	if(dsp->PRAMDMABufCount)
 	 DSP_FinishPRAMDMA();
 	break;
   }
@@ -78,7 +78,7 @@ static NO_INLINE NO_CLONE void MVIInstr(void)
 }
 
 
-MDFN_HIDE extern void (*const DSP_MVIFuncTable[2][16][128])(void) =
+MDFN_HIDE extern void (*const DSP_MVIFuncTable[2][16][128])(DSPS*) =
 {
  #include "scu_dsp_mvitab.inc"
 };

--- a/mednafen/ss/sh7095.h
+++ b/mednafen/ss/sh7095.h
@@ -479,6 +479,9 @@ class SH7095 final
  template<bool EmulateICache, bool IntPreventNext>
  INLINE void DoIDIF_INLINE(void);
 
+ template<bool EmulateICache, bool IntPreventNext>
+ NO_INLINE void DoIDIF_NI(void) MDFN_HOT;
+
  template<bool SlavePenalty, typename T, bool BurstHax>
  INLINE T ExtBusRead_INLINE(uint32 A);
 

--- a/mednafen/ss/sh7095.h
+++ b/mednafen/ss/sh7095.h
@@ -88,8 +88,8 @@ class SH7095 final
  };
 
  sscpu_timestamp_t timestamp;
- sscpu_timestamp_t MA_until;
  sscpu_timestamp_t MM_until;
+ sscpu_timestamp_t MA_until;
  sscpu_timestamp_t write_finish_timestamp;
 
  INLINE void SetT(bool new_value) { SR &= ~1; SR |= new_value; }

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -2753,6 +2753,37 @@ static const uint8 InstrDecodeTab[65536] =
  #include "sh7095_idecodetab.inc"
 };
 
+#ifdef SH7095_OP_PAIR_PROFILE
+namespace {
+ struct OpPairProf {
+  uint32 counter[256][256];
+  uint8 prev_op;
+ };
+ OpPairProf op_pair_prof[2];
+}
+
+#define OP_PAIR_TICK(which_idx)							\
+ do {										\
+  const unsigned _wi = (which_idx);						\
+  const uint8 _curr = (uint8)(Pipe_ID >> 24);					\
+  op_pair_prof[_wi].counter[op_pair_prof[_wi].prev_op][_curr]++;		\
+  op_pair_prof[_wi].prev_op = _curr;						\
+ } while(0)
+
+void SS_DumpOpPairProfile(void)
+{
+ const char* paths[2] = { "/tmp/op_pairs_master.bin", "/tmp/op_pairs_slave.bin" };
+ for(unsigned i = 0; i < 2; i++) {
+  FILE* f = fopen(paths[i], "wb");
+  if(!f) continue;
+  fwrite(&op_pair_prof[i].counter[0][0], sizeof(uint32), 256u * 256u, f);
+  fclose(f);
+ }
+}
+#else
+#define OP_PAIR_TICK(which_idx) do {} while(0)
+#endif
+
 /*								*/
 /* TODO: Stop reading from memory when an exception is pending? */
 /*								*/
@@ -3006,7 +3037,7 @@ static NO_INLINE MDFN_HOT void DoIDIF_NI(void)
 }
 
 template<unsigned which, bool EmulateICache>
-INLINE void SH7095::Step(void)
+FORCE_INLINE void SH7095::Step(void)
 {
  //
  // Ideally, we would place SPEPRecover: after the FRT event check, but doing
@@ -3026,6 +3057,7 @@ INLINE void SH7095::Step(void)
  const unsigned instr_nyb1 = (instr >> 4) & 0xF;
  const unsigned instr_nyb2 = (instr >> 8) & 0xF;
 // asm volatile("":: "a"(instr_nyb1), "d"(instr_nyb2));
+ OP_PAIR_TICK(which);
  //
  #include "sh7095_ops.inc"
  //

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -3004,7 +3004,7 @@ void SS_DumpOpPairProfile(void)
 
 */
 
-#define DoIDIF(IntPreventNext) DoIDIF_NI<which, EmulateICache, IntPreventNext>()
+#define DoIDIF(IntPreventNext) DoIDIF_NI<EmulateICache, IntPreventNext>()
 
 #define OnChipRegRead(T, A) OnChipRegRead_INLINE<T>(A)
 #define ExtBusRead(T, BurstHax, A) ExtBusRead_NI<which, false, T, BurstHax>(A)
@@ -3030,10 +3030,10 @@ INLINE void SH7095::DoIDIF_INLINE(void)
  DoIDIF_MACRO(IntPreventNext);
 }
 
-template<unsigned which, bool EmulateICache, bool IntPreventNext>
-static NO_INLINE MDFN_HOT void DoIDIF_NI(void)
+template<bool EmulateICache, bool IntPreventNext>
+NO_INLINE MDFN_HOT void SH7095::DoIDIF_NI(void)
 {
- CPU[which].DoIDIF_INLINE<EmulateICache, IntPreventNext>();
+ DoIDIF_INLINE<EmulateICache, IntPreventNext>();
 }
 
 template<unsigned which, bool EmulateICache>

--- a/mednafen/ss/sh7095_opdefs.inc
+++ b/mednafen/ss/sh7095_opdefs.inc
@@ -28,6 +28,7 @@
 #define OP_MOV_W_REG_REGINDIR                   case 0x06:case 0x86:
 #define OP_MOV_L_REG_REGINDIR                   case 0x07:case 0x87:
 #define OP_MOV_B_REGINDIR_REG                   case 0x08:case 0x88:
+#define OP_MOV_B_REGINDIR_REG_ID                0x08
 #define OP_MOV_W_REGINDIR_REG                   case 0x09:case 0x89:
 #define OP_MOV_L_REGINDIR_REG                   case 0x0a:case 0x8a:
 #define OP_MOV_B_REG_REGINDIRPD                 case 0x0b:case 0x8b:
@@ -40,6 +41,7 @@
 #define OP_MOV_W_REG0_REGINDIRDISP              case 0x12:case 0x92:
 #define OP_MOV_L_REG_REGINDIRDISP               case 0x13:case 0x93:
 #define OP_MOV_B_REGINDIRDISP_REG0              case 0x14:case 0x94:
+#define OP_MOV_B_REGINDIRDISP_REG0_ID           0x14
 #define OP_MOV_W_REGINDIRDISP_REG0              case 0x15:case 0x95:
 #define OP_MOV_L_REGINDIRDISP_REG               case 0x16:case 0x96:
 #define OP_MOV_B_REG_IDXREGINDIR                case 0x17:case 0x97:
@@ -64,6 +66,7 @@
 #define OP_ADDC_REG_REG                         case 0x2a:case 0xaa:
 #define OP_ADDV_REG_REG                         case 0x2b:case 0xab:
 #define OP_CMP_EQ_IMM_REG0                      case 0x2c:case 0xac:
+#define OP_CMP_EQ_IMM_REG0_ID                   0x2c
 #define OP_CMP_EQ_REG_REG                       case 0x2d:case 0xad:
 #define OP_CMP_HS_REG_REG                       case 0x2e:case 0xae:
 #define OP_CMP_GE_REG_REG                       case 0x2f:case 0xaf:
@@ -78,6 +81,7 @@
 #define OP_DMULS_L_REG_REG                      case 0x38:case 0xb8:
 #define OP_DMULU_L_REG_REG                      case 0x39:case 0xb9:
 #define OP_DT                                   case 0x3a:case 0xba:
+#define OP_DT_ID                                0x3a
 #define OP_EXTS_B_REG_REG                       case 0x3b:case 0xbb:
 #define OP_EXTS_W_REG_REG                       case 0x3c:case 0xbc:
 #define OP_EXTU_B_REG_REG                       case 0x3d:case 0xbd:
@@ -102,6 +106,7 @@
 #define OP_TAS_B_REGINDIR                       case 0x50:case 0xd0:
 #define OP_TST_REG_REG                          case 0x51:case 0xd1:
 #define OP_TST_IMM_REG0                         case 0x52:case 0xd2:
+#define OP_TST_IMM_REG0_ID                      0x52
 #define OP_TST_B_IMM_IDXGBRINDIR                case 0x53:case 0xd3:
 #define OP_XOR_REG_REG                          case 0x54:case 0xd4:
 #define OP_XOR_IMM_REG0                         case 0x55:case 0xd5:
@@ -120,8 +125,10 @@
 #define OP_SHLL16_REG                           case 0x62:case 0xe2:
 #define OP_SHLR16_REG                           case 0x63:case 0xe3:
 #define OP_BF                                   case 0x64: /* (slot illegal) */
+#define OP_BF_ID                                0x64
 #define OP_BF_S                                 case 0x65: /* (slot illegal) */
 #define OP_BT                                   case 0x66: /* (slot illegal) */
+#define OP_BT_ID                                0x66
 #define OP_BT_S                                 case 0x67: /* (slot illegal) */
 #define OP_BRA                                  case 0x68: /* (slot illegal) */
 #define OP_BRAF_REG                             case 0x69: /* (slot illegal) */
@@ -137,6 +144,7 @@
 #define OP_LDS                                  case 0x73:case 0xf3:
 #define OP_LDS_L                                case 0x74:case 0xf4:
 #define OP_NOP                                  case 0x75:case 0xf5:
+#define OP_NOP_ID                               0x75
 #define OP_RTE                                  case 0x76: /* (slot illegal) */
 #define OP_SETT                                 case 0x77:case 0xf7:
 #define OP_SLEEP                                case 0x78:case 0xf8:

--- a/mednafen/ss/sh7095_ops.inc
+++ b/mednafen/ss/sh7095_ops.inc
@@ -6,13 +6,79 @@ switch(Pipe_ID >> 24)
  
  #define BEGIN_OP(x)		OP_##x { PART_OP_NORMIDIF
  #define BEGIN_OP_FUDGEIF(x)	OP_##x { if(EmulateICache) { UCRead_IF_Kludge = false; } DoIDIF(false); if(EmulateICache) { timestamp -= UCRead_IF_Kludge; }
- #define BEGIN_OP_DLYIDIF(x)	OP_##x { 
+ #define BEGIN_OP_DLYIDIF(x)	OP_##x {
 
  // "Interrupt-disabled" instruction(blocks interrupt from being taken for next instruction).
  // Use with BEGIN_OP_DLYIDIF()
  #define PART_OP_INTDIS { DoIDIF(true); }
 
  #define END_OP } break;
+
+ // Pair fusion: at the end of a setter-of-T's handler, after its DoIDIF has
+ // populated Pipe_ID with the next op-id, take the inlined cond-branch path
+ // when the next op is the matching BF/BT (and no exception is pending --
+ // EPending ORs 0xFF000000 into Pipe_ID, so the equality fails closed).
+ // The extra PC += 2 compensates for the post-switch PC += 2 only firing
+ // once for the two folded instructions; cycle accounting matches the
+ // unfused path (one fetch in this op's DoIDIF, one in the inlined branch's).
+ // Skipped in the slave resume path (RunSlaveUntil) because DoIDIF can yield
+ // via CHECK_EXIT_RESUME and br_instr is a stack local that won't survive.
+ #if !defined(SH7095_OP_PAIR_PROFILE) && !defined(SH7095_NEED_RESUME_TABLE_INIT) && defined(_LOW_ACCURACY_)
+ #define FUSE_COND_BRANCH(next_op_id, cond_expr)				\
+  if(MDFN_LIKELY((Pipe_ID >> 24) == (next_op_id)))			\
+  {									\
+   const uint16 br_instr = (uint16)Pipe_ID;				\
+   PC += 2;								\
+   if(EmulateICache) { UCRead_IF_Kludge = false; }			\
+   DoIDIF(false);							\
+   if(EmulateICache) { timestamp -= UCRead_IF_Kludge; }			\
+   CondRelBranch((cond_expr), (uint32)(int8)br_instr << 1);		\
+  }
+ // Delay-slot fusion: collapse a NOP delay slot into its preceding
+ // delay-branch handler.  After DelayBranch(), Pipe_ID's high byte is
+ // (InstrDecodeTab[delay_slot] | 0x80) -- so for a NOP delay slot it's
+ // 0xF5.  We inline the NOP's empty-body dispatch as PC += 2 + DoIDIF,
+ // saving one switch round-trip when this fires.  Hot for the slave's
+ // interrupt-storm cycle (RTE -> NOP delay -> PSEUDO_EPENDING -> RTE),
+ // where RTE -> NOP transitions are 100% in profiling.
+ #define FUSE_DELAY_SLOT_NOP()						\
+  if(MDFN_LIKELY((Pipe_ID >> 24) == (OP_NOP_ID | 0x80)))		\
+  {									\
+   PC += 2;								\
+   DoIDIF(false);							\
+  }
+ // Triplet fusion: load -> cmp/tst -> conditional branch.  At the load's
+ // tail, Pipe_ID has the cmp/tst (decoded by the load's BEGIN_OP DoIDIF)
+ // and Pipe_IF has the branch instruction word (raw uint16, op-id NOT yet
+ // computed -- DoID decodes during rotation).  Detection therefore needs an
+ // explicit InstrDecodeTab lookup on Pipe_IF; the high byte of Pipe_IF is
+ // always zero (FetchIF only writes a uint16) so testing it would fail
+ // closed.  alu_set_t_expr reads alu_instr (uint16) as the cmp/tst word.
+ // The two DoIDIF_INLINE calls model the cmp/tst's and the branch's fetch
+ // slots; PC interleaves +=2 between them so each fetches the right address.
+ // The branch's slot keeps its FUDGEIF kludge wrap.  Total PC advance =
+ // 2+2 inside macro + 2 post-switch = 6 bytes for 3 folded instructions.
+ #define FUSE_LOAD_CMPTST_BRANCH(alu_op_id, br_op_id, alu_set_t_expr, br_cond_expr)	\
+  if(MDFN_LIKELY((Pipe_ID >> 24) == (alu_op_id) &&					\
+                 InstrDecodeTab[(uint16)Pipe_IF] == (br_op_id)))			\
+  {											\
+   const uint16 alu_instr = (uint16)Pipe_ID;						\
+   const uint16 br_instr = (uint16)Pipe_IF;						\
+   WB_EX_CHECK(0)									\
+   alu_set_t_expr;									\
+   PC += 2;										\
+   DoIDIF_INLINE<EmulateICache, false>();						\
+   PC += 2;										\
+   if(EmulateICache) { UCRead_IF_Kludge = false; }					\
+   DoIDIF_INLINE<EmulateICache, false>();						\
+   if(EmulateICache) { timestamp -= UCRead_IF_Kludge; }					\
+   CondRelBranch((br_cond_expr), (uint32)(int8)br_instr << 1);				\
+  }
+ #else
+ #define FUSE_COND_BRANCH(next_op_id, cond_expr) do {} while(0)
+ #define FUSE_LOAD_CMPTST_BRANCH(alu_op_id, br_op_id, alu_set_t_expr, br_cond_expr) do {} while(0)
+ #define FUSE_DELAY_SLOT_NOP() do {} while(0)
+ #endif
 
  #define WB_EX_CHECK(r) { if(timestamp < WB_until[(r)]) timestamp = WB_until[(r)]; }
  #define WB_WRITE(r, v) { R[(r)] = (v); WB_until[(r)] = MA_until + 1; }
@@ -120,6 +186,9 @@ switch(Pipe_ID >> 24)
 	CONST_VAR(uint32, ea) = R[m];
 
 	WB_READ8(instr_nyb2, ea);
+
+	FUSE_LOAD_CMPTST_BRANCH(OP_CMP_EQ_IMM_REG0_ID, OP_BF_ID,
+		SetT((int32)(int8)alu_instr == (int32)R[0]), !GetT());
  END_OP
 
 
@@ -281,6 +350,9 @@ switch(Pipe_ID >> 24)
 	CONST_VAR(uint32, ea) = R[m] + (d << 0);
 
 	WB_READ8(0, ea);
+
+	FUSE_LOAD_CMPTST_BRANCH(OP_TST_IMM_REG0_ID, OP_BT_ID,
+		SetT(!(R[0] & (uint8)alu_instr)), GetT());
  END_OP
 
 
@@ -578,6 +650,8 @@ switch(Pipe_ID >> 24)
 	WB_EX_CHECK(0)
 
 	SetT(imm == R[0]);
+
+	FUSE_COND_BRANCH(OP_BF_ID, !GetT());
  END_OP
 
 
@@ -648,6 +722,8 @@ switch(Pipe_ID >> 24)
 	WB_EX_CHECK(m)
 
 	SetT((int32)R[n] > (int32)R[m]);
+
+	FUSE_COND_BRANCH(OP_BT_ID, GetT());
  END_OP
 
 
@@ -769,6 +845,8 @@ switch(Pipe_ID >> 24)
 
 	R[n]--;
 	SetT(!R[n]);
+
+	FUSE_COND_BRANCH(OP_BF_ID, !GetT());
  END_OP
 
 
@@ -1203,6 +1281,9 @@ switch(Pipe_ID >> 24)
 	WB_EX_CHECK(m)
 
 	SetT(!(R[n] & R[m]));
+
+	FUSE_COND_BRANCH(OP_BF_ID, !GetT());
+	FUSE_COND_BRANCH(OP_BT_ID, GetT());
  END_OP
 
 
@@ -1215,6 +1296,8 @@ switch(Pipe_ID >> 24)
 	WB_EX_CHECK(0)
 
 	SetT(!(R[0] & imm));
+
+	FUSE_COND_BRANCH(OP_BT_ID, GetT());
  END_OP
 
 
@@ -1457,6 +1540,7 @@ switch(Pipe_ID >> 24)
  //
  BEGIN_OP_FUDGEIF(BF_S)
 	CondRelDelayBranch(!GetT(), (uint32)(int8)instr << 1);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1473,6 +1557,7 @@ switch(Pipe_ID >> 24)
  //
  BEGIN_OP_FUDGEIF(BT_S)
 	CondRelDelayBranch(GetT(), (uint32)(int8)instr << 1);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1481,6 +1566,7 @@ switch(Pipe_ID >> 24)
  //
  BEGIN_OP_DLYIDIF(BRA)
 	UCRelDelayBranch((uint32)sign_x_to_s32(12, instr) << 1);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1489,6 +1575,7 @@ switch(Pipe_ID >> 24)
  //
  BEGIN_OP_DLYIDIF(BRAF_REG)
 	UCRelDelayBranch(R[instr_nyb2]);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1499,6 +1586,7 @@ switch(Pipe_ID >> 24)
 	PR = PC;
 
 	UCRelDelayBranch((uint32)sign_x_to_s32(12, instr) << 1);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1509,6 +1597,7 @@ switch(Pipe_ID >> 24)
 	PR = PC;
 
 	UCRelDelayBranch(R[instr_nyb2]);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1517,6 +1606,7 @@ switch(Pipe_ID >> 24)
  //
  BEGIN_OP_DLYIDIF(JMP_REGINDIR)
 	UCDelayBranch(R[instr_nyb2]);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1527,6 +1617,7 @@ switch(Pipe_ID >> 24)
 	PR = PC;
 
 	UCDelayBranch(R[instr_nyb2]);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1535,6 +1626,7 @@ switch(Pipe_ID >> 24)
  //
  BEGIN_OP_DLYIDIF(RTS)
 	UCDelayBranch(PR);
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -1657,6 +1749,8 @@ switch(Pipe_ID >> 24)
 	timestamp++;
 
 	DelayBranch(opexec_new_PC);
+
+	FUSE_DELAY_SLOT_NOP();
  END_OP
 
 
@@ -2019,6 +2113,9 @@ static_assert(__COUNTER__ == ((DebugMode ? 10000 : 5000) + 393 + 512 + 1), "Unex
 #undef BEGIN_OP_DLYIDIF
 #undef PART_OP_INTDIS
 #undef END_OP
+#undef FUSE_COND_BRANCH
+#undef FUSE_LOAD_CMPTST_BRANCH
+#undef FUSE_DELAY_SLOT_NOP
 #undef WB_EX_CHECK
 #undef WB_WRITE
 #undef WB_READ8

--- a/mednafen/ss/sh7095s_rsu.inc
+++ b/mednafen/ss/sh7095s_rsu.inc
@@ -30,6 +30,7 @@
   }
 
   instr = (uint16)Pipe_ID;
+  OP_PAIR_TICK(1);
   //
   #include "sh7095_ops.inc"
   //

--- a/mednafen/ss/ss.cpp
+++ b/mednafen/ss/ss.cpp
@@ -418,9 +418,20 @@ void SS_SetPhysMemMap(uint32 Astart, uint32 Aend, uint16* ptr, uint32 length, bo
 //     functions.
 //
 int Running;
-event_list_entry events[SS_EVENT__COUNT];
+alignas(16) event_list_entry events[SS_EVENT__SIMD_COUNT];
+static ss_event_handler event_handlers[SS_EVENT__COUNT];
 
 static sscpu_timestamp_t next_event_ts;
+
+// NO_INLINE keeps the body out of RunLoop's no-unroll pragma scope so -O2
+// auto-vectorizes the reduction (smin/sminv on aarch64).
+static NO_INLINE sscpu_timestamp_t FindNextEventTS(void)
+{
+ sscpu_timestamp_t m = SS_EVENT_DISABLED_TS;
+ for(unsigned i = 0; i < SS_EVENT__SIMD_COUNT; i++)
+  m = std::min(m, events[i].event_time);
+ return m;
+}
 
 template<unsigned c>
 static sscpu_timestamp_t SH_DMA_EventHandler(sscpu_timestamp_t et)
@@ -441,38 +452,38 @@ static sscpu_timestamp_t SH_DMA_EventHandler(sscpu_timestamp_t et)
 
 static MDFN_COLD void InitEvents(void)
 {
- for(unsigned i = 0; i < SS_EVENT__COUNT; i++)
+ // SYNFIRST/SYNLAST and padding slots stay disabled so the min-reduction
+ // ignores them; only [SYNFIRST+1, SYNLAST) hold real events.
+ for(unsigned i = 0; i < SS_EVENT__SIMD_COUNT; i++)
  {
-  if(i == SS_EVENT__SYNFIRST)
-   events[i].event_time = 0;
-  else if(i == SS_EVENT__SYNLAST)
-   events[i].event_time = 0x7FFFFFFF;
+  if(i == SS_EVENT__SYNFIRST || i == SS_EVENT__SYNLAST || i >= SS_EVENT__COUNT)
+   events[i].event_time = SS_EVENT_DISABLED_TS;
   else
-   events[i].event_time = 0; //SS_EVENT_DISABLED_TS;
-
-  events[i].prev = (i > 0) ? &events[i - 1] : NULL;
-  events[i].next = (i < (SS_EVENT__COUNT - 1)) ? &events[i + 1] : NULL;
+   events[i].event_time = 0;
  }
 
- events[SS_EVENT_SH2_M_DMA].event_handler = &SH_DMA_EventHandler<0>;
- events[SS_EVENT_SH2_S_DMA].event_handler = &SH_DMA_EventHandler<1>;
+ for(unsigned i = 0; i < SS_EVENT__COUNT; i++)
+  event_handlers[i] = NULL;
 
- events[SS_EVENT_SCU_DMA].event_handler = SCU_UpdateDMA;
- events[SS_EVENT_SCU_DSP].event_handler = SCU_UpdateDSP;
-/*events[SS_EVENT_SCU_INT].event_handler = SCU_UpdateInt;*/
+ event_handlers[SS_EVENT_SH2_M_DMA] = &SH_DMA_EventHandler<0>;
+ event_handlers[SS_EVENT_SH2_S_DMA] = &SH_DMA_EventHandler<1>;
 
- events[SS_EVENT_SMPC].event_handler = SMPC_Update;
+ event_handlers[SS_EVENT_SCU_DMA] = SCU_UpdateDMA;
+ event_handlers[SS_EVENT_SCU_DSP] = SCU_UpdateDSP;
+/*event_handlers[SS_EVENT_SCU_INT] = SCU_UpdateInt;*/
 
- events[SS_EVENT_VDP1].event_handler = VDP1::Update;
- events[SS_EVENT_VDP2].event_handler = VDP2::Update;
+ event_handlers[SS_EVENT_SMPC] = SMPC_Update;
 
- events[SS_EVENT_CDB].event_handler = CDB_Update;
+ event_handlers[SS_EVENT_VDP1] = VDP1::Update;
+ event_handlers[SS_EVENT_VDP2] = VDP2::Update;
 
- events[SS_EVENT_SOUND].event_handler = SOUND_Update;
+ event_handlers[SS_EVENT_CDB] = CDB_Update;
 
- events[SS_EVENT_CART].event_handler = CART_GetEventHandler();
+ event_handlers[SS_EVENT_SOUND] = SOUND_Update;
 
- events[SS_EVENT_MIDSYNC].event_handler = MidSync;
+ event_handlers[SS_EVENT_CART] = CART_GetEventHandler();
+
+ event_handlers[SS_EVENT_MIDSYNC] = MidSync;
  //
  //
  SS_SetEventNT(&events[SS_EVENT_MIDSYNC], SS_EVENT_DISABLED_TS);
@@ -480,66 +491,28 @@ static MDFN_COLD void InitEvents(void)
 
 static void RebaseTS(const sscpu_timestamp_t timestamp)
 {
- for(unsigned i = 0; i < SS_EVENT__COUNT; i++)
+ for(unsigned i = SS_EVENT__SYNFIRST + 1; i < SS_EVENT__SYNLAST; i++)
  {
-  if(i == SS_EVENT__SYNFIRST || i == SS_EVENT__SYNLAST)
-   continue;
-
   assert(events[i].event_time > timestamp);
 
   if(events[i].event_time != SS_EVENT_DISABLED_TS)
    events[i].event_time -= timestamp;
  }
 
- next_event_ts = events[SS_EVENT__SYNFIRST].next->event_time;
+ next_event_ts = FindNextEventTS();
 }
 
 void SS_SetEventNT(event_list_entry* e, const sscpu_timestamp_t next_timestamp)
 {
- if(next_timestamp < e->event_time)
- {
-  event_list_entry *fe = e;
+ const sscpu_timestamp_t old_t = e->event_time;
+ e->event_time = next_timestamp;
 
-  do
-  {
-   fe = fe->prev;
-  } while(next_timestamp < fe->event_time);
-
-  // Remove this event from the list, temporarily of course.
-  e->prev->next = e->next;
-  e->next->prev = e->prev;
-
-  // Insert into the list, just after "fe".
-  e->prev = fe;
-  e->next = fe->next;
-  fe->next->prev = e;
-  fe->next = e;
-
-  e->event_time = next_timestamp;
- }
- else if(next_timestamp > e->event_time)
- {
-  event_list_entry *fe = e;
-
-  do
-  {
-   fe = fe->next;
-  } while(next_timestamp > fe->event_time);
-
-  // Remove this event from the list, temporarily of course
-  e->prev->next = e->next;
-  e->next->prev = e->prev;
-
-  // Insert into the list, just BEFORE "fe".
-  e->prev = fe->prev;
-  e->next = fe;
-  fe->prev->next = e;
-  fe->prev = e;
-
-  e->event_time = next_timestamp;
- }
-
- next_event_ts = ((Running > 0) ? events[SS_EVENT__SYNFIRST].next->event_time : 0);
+ if(MDFN_UNLIKELY(Running <= 0))
+  next_event_ts = 0;
+ else if(old_t == next_event_ts)
+  next_event_ts = FindNextEventTS();
+ else if(next_timestamp < next_event_ts)
+  next_event_ts = next_timestamp;
 }
 
 // Called from debug.cpp too.
@@ -551,24 +524,31 @@ static void ForceEventUpdates(const sscpu_timestamp_t timestamp)
  for(unsigned evnum = SS_EVENT__SYNFIRST + 1; evnum < SS_EVENT__SYNLAST; evnum++)
  {
   if(events[evnum].event_time != SS_EVENT_DISABLED_TS)
-   SS_SetEventNT(&events[evnum], events[evnum].event_handler(timestamp));
+   events[evnum].event_time = event_handlers[evnum](timestamp);
  }
 
- next_event_ts = ((Running > 0) ? events[SS_EVENT__SYNFIRST].next->event_time : 0);
+ next_event_ts = (Running > 0) ? FindNextEventTS() : 0;
 }
 
 static INLINE bool EventHandler(const sscpu_timestamp_t timestamp)
 {
- event_list_entry *e = NULL;
-
- while(timestamp >= (e = events[SS_EVENT__SYNFIRST].next)->event_time)  // If Running = 0, EventHandler() may be called even if there isn't an event per-se, so while() instead of do { ... } while
+ // next_event_ts is forced to 0 (sentinel) when Running <= 0 to make
+ // CheckEventsByMemTS trip and unwind RunLoop. Don't enter the dispatch loop
+ // in that state best_t = 0 wouldn't match any events[i].event_time and
+ // the inner scan would walk off the end.
+ if(MDFN_UNLIKELY(Running <= 0))
+  return false;
+ sscpu_timestamp_t best_t = next_event_ts;
+ while(best_t <= timestamp)
  {
-  sscpu_timestamp_t nt;
-  nt = e->event_handler(e->event_time);
-
-  SS_SetEventNT(e, nt);
+  unsigned best_i = SS_EVENT__SYNFIRST + 1;
+  while(events[best_i].event_time != best_t)
+   best_i++;
+  events[best_i].event_time = event_handlers[best_i](best_t);
+  best_t = FindNextEventTS();
  }
 
+ next_event_ts = (Running > 0) ? best_t : 0;
  return Running > 0;
 }
 
@@ -1219,25 +1199,25 @@ struct EventsPacker
 
 INLINE void EventsPacker::Save(void)
 {
- event_list_entry* evt = events[SS_EVENT__SYNFIRST].next;
-
- for(size_t i = eventcopy_first; i < eventcopy_bound; i++)
+ for(size_t i = 0; i < eventcopy_bound - eventcopy_first; i++)
  {
-  event_times[i - eventcopy_first] = events[i].event_time;
-  event_order[i - eventcopy_first] = evt - events;
-  assert(event_order[i - eventcopy_first] >= eventcopy_first && event_order[i - eventcopy_first] < eventcopy_bound);
-  evt = evt->next;
+  event_times[i] = events[eventcopy_first + i].event_time;
+  event_order[i] = (uint8)(eventcopy_first + i);
  }
+
+ // event_order is the schedule order Restore() validates; equal times tie-break by index.
+ std::stable_sort(event_order, event_order + (eventcopy_bound - eventcopy_first),
+  [](uint8 a, uint8 b) { return events[a].event_time < events[b].event_time; });
 }
 
 INLINE bool EventsPacker::Restore(const unsigned state_version)
 {
  bool used[SS_EVENT__COUNT] = { 0 };
- event_list_entry* evt = &events[SS_EVENT__SYNFIRST];
- for(size_t i = eventcopy_first; i < eventcopy_bound; i++)
+
+ for(size_t i = 0; i < eventcopy_bound - eventcopy_first; i++)
  {
-  int32 et = event_times[i - eventcopy_first];
-  uint8 eo = event_order[i - eventcopy_first];
+  int32 et = event_times[i];
+  uint8 eo = event_order[i];
 
   if(state_version < 0x00102600 && et >= 0x40000000)
   {
@@ -1260,47 +1240,17 @@ INLINE bool EventsPacker::Restore(const unsigned state_version)
 
   used[eo] = true;
 
-  if(et < events[SS_EVENT__SYNFIRST].event_time)
+  if(et < 0)
    return false;
 
-  events[i].event_time = et;
-
-  evt->next = &events[eo];
-  evt->next->prev = evt;
-  evt = evt->next;
+  events[eventcopy_first + i].event_time = et;
  }
- evt->next = &events[SS_EVENT__SYNLAST];
- evt->next->prev = evt;
 
- for(size_t i = 0; i < SS_EVENT__COUNT; i++)
+ // Reject malformed save states whose event_order isn't non-decreasing.
+ for(size_t i = 1; i < eventcopy_bound - eventcopy_first; i++)
  {
-  if(i == SS_EVENT__SYNLAST)
-  {
-   if(events[i].next != NULL)
-    return false;
-  }
-  else
-  {
-   if(events[i].next->prev != &events[i])
-    return false;
-
-   if(events[i].next->event_time < events[i].event_time)
-    return false;
-  }
-
-  if(i == SS_EVENT__SYNFIRST)
-  {
-   if(events[i].prev != NULL)
-    return false;
-  }
-  else
-  {
-   if(events[i].prev->next != &events[i])
-    return false;
-
-   if(events[i].prev->event_time > events[i].event_time)
-    return false;
-  }
+  if(events[event_order[i]].event_time < events[event_order[i - 1]].event_time)
+   return false;
  }
 
  return true;

--- a/mednafen/ss/ss.cpp
+++ b/mednafen/ss/ss.cpp
@@ -1020,6 +1020,9 @@ MDFN_COLD void CloseGame(void)
 {
  //
  //
+#ifdef SH7095_OP_PAIR_PROFILE
+ SS_DumpOpPairProfile();
+#endif
 
  SaveBackupRAM();
  SaveCartNV();

--- a/mednafen/ss/ss.h
+++ b/mednafen/ss/ss.h
@@ -146,17 +146,18 @@
   SS_EVENT__COUNT,
  };
 
+ // events[] is padded so FindNextEventTS() can min-reduce over whole vectors;
+ // padding slots stay at SS_EVENT_DISABLED_TS.
+ enum { SS_EVENT__SIMD_COUNT = (SS_EVENT__COUNT + 3) & ~3 };
+
  typedef sscpu_timestamp_t (*ss_event_handler)(const sscpu_timestamp_t timestamp);
 
  struct event_list_entry
  {
   sscpu_timestamp_t event_time;
-  event_list_entry *prev;
-  event_list_entry *next;
-  ss_event_handler event_handler;
  };
 
- MDFN_HIDE extern event_list_entry events[SS_EVENT__COUNT];
+ MDFN_HIDE extern event_list_entry events[SS_EVENT__SIMD_COUNT];
 
  enum : sscpu_timestamp_t { SS_EVENT_DISABLED_TS = 0x7FFFFFFF };
 

--- a/mednafen/ss/vdp2.cpp
+++ b/mednafen/ss/vdp2.cpp
@@ -821,6 +821,24 @@ uint32 Write16_DB(uint32 A, uint16 DB)
  return RW<uint16, true>(A, &DB);
 }
 
+uint32 Write16Burst_DB(uint32 base, uint32 n16, uint32 add_mode, const uint16* words)
+{
+ VDP2REND_WriteBurst16_DB(base, n16, add_mode, words);
+
+ const uint32 stride = (1u << add_mode) &~ 1u;
+ uint32 a = base;
+ uint32 penalty_sum = 0;
+
+ for(uint32 i = 0; i < n16; i++)
+ {
+  uint16 w = words[i];
+  penalty_sum += RW<uint16, true>(a, &w);
+  a += stride;
+ }
+
+ return penalty_sum;
+}
+
 
 //
 //

--- a/mednafen/ss/vdp2.h
+++ b/mednafen/ss/vdp2.h
@@ -27,6 +27,9 @@ namespace VDP2
 
 uint32 Write8_DB(uint32 A, uint16 DB) MDFN_HOT;
 uint32 Write16_DB(uint32 A, uint16 DB) MDFN_HOT;
+// DSP-DMA burst of n16 16-bit writes into the VDP2 window: words[i] -> (base + i*((1<<add_mode)&~1)).
+// Performs the SH2-side array writes here and queues a single renderer burst; returns the summed VRAM access penalty.
+uint32 Write16Burst_DB(uint32 base, uint32 n16, uint32 add_mode, const uint16* words) MDFN_HOT;
 uint16 Read16_DB(uint32 A) MDFN_HOT;
 
 void Init(const bool IsPAL, const uint64 affinity) MDFN_COLD;

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -3194,6 +3194,8 @@ static void/*int*/ RThreadEntry(void* data)
    {
 #ifdef MDFN_SS_BUSYWAIT_PAUSE
     asm volatile("pause\n\tpause\n\tpause\n\tpause\n\tpause\n\tpause\n\tpause\n\t");
+#elif defined(__aarch64__) || defined(__arm__)
+    asm volatile("yield\n\tyield\n\tyield\n\tyield\n\tyield\n\tyield\n\tyield\n\t");
 #else
     for(int i = 1000; i; i--)
     {

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -3134,28 +3134,56 @@ struct WQ_Entry
 };
 
 static std::array<WQ_Entry, 0x80000> WQ;
-static size_t WQ_ReadPos, WQ_WritePos;
-static std::atomic_uint_least32_t WQ_InCount;
-static std::atomic_int_least32_t DrawCounter;
+// SPSC queue state. Each atomic is written by exactly one thread (release-store)
+// and read by the other (acquire-load); live queue depth is recovered by
+// subtraction, avoiding the cross-thread RMW that bounced the cache line.
+// Producer-side and consumer-side state live on separate cache lines so the
+// consumer's pop-side writes don't thrash the producer's reads of its own
+// counters. WQ_PopCached lets WWQ skip the per-call atomic load on the
+// queue-full check. DrawFinishCount (consumer-written) is read directly by
+// the producer because the wakeup heuristic needs an up-to-date queue depth;
+// DrawPushCount (producer-written) mirrors Prod.DrawPushLocal so the consumer
+// can tell when it has finished every DRAW_LINE the producer queued and wake
+// EndFrame's drain wait.
+alignas(64) static std::atomic_uint_least32_t WQ_PushCount;     // producer-written
+alignas(64) static std::atomic_uint_least32_t WQ_PopCount;      // consumer-written
+alignas(64) static std::atomic_uint_least32_t DrawFinishCount;  // consumer-written
+alignas(64) static std::atomic_uint_least32_t DrawPushCount;    // producer-written
+struct alignas(64) ProducerState
+{
+ size_t WritePos;
+ uint32 PushLocal;        // total WQ pushes
+ uint32 DrawPushLocal;    // total VDP2REND_DrawLine pushes
+ uint32 WQ_PopCached;     // last-seen WQ_PopCount; refreshed only when the queue
+                          // appears full (huge queue, so basically never)
+};
+struct alignas(64) ConsumerState
+{
+ size_t ReadPos;
+ uint32 PopLocal;         // total WQ pops
+ uint32 DrawFinishLocal;  // total DrawLine completions
+};
+static ProducerState Prod;
+static ConsumerState Cons;
 static bool DoBusyWait;
 ssem_t* WakeupSem;
 
 // Drain coordination: when EndFrame is called the producer has to wait
-// for the consumer thread to drain the rest of this frame's DRAW_LINE
-// commands (DrawCounter going back to zero). The old implementation
-// spun: ssem_signal(WakeupSem) + retro_sleep(0) repeatedly until the
-// counter hit zero. That works but burns producer CPU on every frame
-// transition for as long as the consumer takes -- and on some systems
-// retro_sleep(0) is implemented as sched_yield() which keeps the
-// producer at the head of the runqueue, defeating the yield.
+// for the consumer to finish this frame's DRAW_LINE commands -- i.e. for
+// DrawFinishCount to catch up to the producer's DrawPushLocal. The old
+// implementation spun: ssem_signal(WakeupSem) + retro_sleep repeatedly
+// until the two were equal. That works but burns producer CPU on every
+// frame transition for as long as the consumer takes -- and on some
+// systems retro_sleep(0) is implemented as sched_yield(), which keeps
+// the producer at the head of the runqueue, defeating the yield.
 //
 // Replacement: a mutex+condvar pair. EndFrame waits on scond_wait
 // (proper kernel block, zero spinning); the consumer's COMMAND_DRAW_LINE
-// handler signals on the fetch_sub that takes DrawCounter to zero.
-// Per-frame overhead: 1 lock+unlock+wait on the producer, 1 lock+
-// signal+unlock on the consumer (only for the line that hits zero,
-// not every line). Net change: a few microseconds of overhead per
-// frame, in exchange for zero CPU spent spinning during the drain.
+// handler signals once -- on the completion that makes DrawFinishLocal
+// reach the published DrawPushCount. Per-frame overhead: 1 lock+unlock+
+// wait on the producer, 1 lock+signal+unlock on the consumer (only for
+// the line that drains the frame, not every line). A few microseconds
+// per frame, in exchange for zero CPU spent spinning during the drain.
 static slock_t  *DrainLock = NULL;
 static scond_t  *DrainCond = NULL;
 static bool DoWakeupIfNecessary;
@@ -3167,17 +3195,21 @@ static INLINE void WWQ(uint16 command, uint32 arg32 = 0, uint16 arg16 = 0)
  // tick by default, which would have wedged the producer for almost a
  // whole frame each time the queue filled. retro_sleep(0) yields to the
  // scheduler without that minimum dwell.
- while(MDFN_UNLIKELY(WQ_InCount.load(std::memory_order_acquire) == WQ.size()))
-  retro_sleep(0);
+ while(MDFN_UNLIKELY(Prod.PushLocal - Prod.WQ_PopCached == WQ.size()))
+ {
+  Prod.WQ_PopCached = WQ_PopCount.load(std::memory_order_acquire);
+  if(Prod.PushLocal - Prod.WQ_PopCached == WQ.size())
+   retro_sleep(0);
+ }
 
- WQ_Entry* wqe = &WQ[WQ_WritePos];
+ WQ_Entry* wqe = &WQ[Prod.WritePos];
 
  wqe->Command = command;
  wqe->Arg16 = arg16;
  wqe->Arg32 = arg32;
 
- WQ_WritePos = (WQ_WritePos + 1) % WQ.size();
- WQ_InCount.fetch_add(1, std::memory_order_release);
+ Prod.WritePos = (Prod.WritePos + 1) % WQ.size();
+ WQ_PushCount.store(++Prod.PushLocal, std::memory_order_release);
 }
 
 static void/*int*/ RThreadEntry(void* data)
@@ -3186,7 +3218,7 @@ static void/*int*/ RThreadEntry(void* data)
 
  while(MDFN_LIKELY(Running))
  {
-  while(MDFN_UNLIKELY(WQ_InCount.load(std::memory_order_acquire) == 0))
+  while(MDFN_UNLIKELY(WQ_PushCount.load(std::memory_order_acquire) == Cons.PopLocal))
   {
    if(!DoBusyWait)
     ssem_wait(WakeupSem);
@@ -3211,7 +3243,7 @@ static void/*int*/ RThreadEntry(void* data)
   //
   //
   //
-  WQ_Entry* wqe = &WQ[WQ_ReadPos];
+  WQ_Entry* wqe = &WQ[Cons.ReadPos];
 
   switch(wqe->Command)
   {
@@ -3227,15 +3259,16 @@ static void/*int*/ RThreadEntry(void* data)
 	//for(unsigned i = 0; i < 2; i++)
 	DrawLine((uint16)wqe->Arg32, wqe->Arg32 >> 16, wqe->Arg16);
 	//
-	// fetch_sub returns the old value, so the transition-to-zero is
-	// when the OLD value was 1. Signal the drain condvar only on that
-	// transition -- the producer is waiting in EndFrame for this
-	// exact moment. The slock_lock / unlock pair around scond_signal
-	// is required by the POSIX-style API even though our visible
-	// state is the atomic DrawCounter; without the lock there's a
-	// classic missed-wakeup race window between the producer's
-	// load() and its scond_wait().
-	if (DrawCounter.fetch_sub(1, std::memory_order_release) == 1)
+	// Publish completion: DrawFinishCount is consumer-written, read by
+	// the producer (EndFrame's drain wait, and the wdcq wakeup
+	// heuristic in VDP2REND_DrawLine). If this completion brings us
+	// level with everything the producer has queued so far, and
+	// EndFrame is blocked on the drain condvar, wake it. The
+	// slock_lock / unlock pair around scond_signal closes the
+	// missed-wakeup race between EndFrame's recheck and its scond_wait;
+	// scond_signal with no waiter is a harmless no-op.
+	DrawFinishCount.store(++Cons.DrawFinishLocal, std::memory_order_release);
+	if (Cons.DrawFinishLocal == DrawPushCount.load(std::memory_order_acquire))
 	{
 	   slock_lock(DrainLock);
 	   scond_signal(DrainCond);
@@ -3262,8 +3295,8 @@ static void/*int*/ RThreadEntry(void* data)
   //
   //
   //
-  WQ_ReadPos = (WQ_ReadPos + 1) % WQ.size();
-  WQ_InCount.fetch_sub(1, std::memory_order_release);
+  Cons.ReadPos = (Cons.ReadPos + 1) % WQ.size();
+  WQ_PopCount.store(++Cons.PopLocal, std::memory_order_release);
  }
 
  // return 0; // Libretro fix
@@ -3283,10 +3316,12 @@ void VDP2REND_Init(const bool IsPAL, const uint64 affinity)
  UserLayerEnableMask = ~0U;
  Clock28M = false;
  //
- WQ_ReadPos = 0;
- WQ_WritePos = 0;
- WQ_InCount.store(0, std::memory_order_release); 
- DrawCounter.store(0, std::memory_order_release);
+ Prod = {};
+ Cons = {};
+ WQ_PushCount.store(0, std::memory_order_release);
+ WQ_PopCount.store(0, std::memory_order_release);
+ DrawFinishCount.store(0, std::memory_order_release);
+ DrawPushCount.store(0, std::memory_order_release);
  WakeupSem = ssem_new(0);
  DrainLock = slock_new();
  DrainCond = scond_new();
@@ -3411,23 +3446,24 @@ void VDP2REND_StartFrame(EmulateSpecStruct* espec_arg, const bool clock28m, cons
 void VDP2REND_EndFrame(void)
 {
  // Wait for the consumer thread to finish all queued DRAW_LINE
- // commands for this frame. Replaces an old spin-yield loop
- // (ssem_signal(WakeupSem) + retro_sleep(0) repeatedly) with a
- // condvar wait. The consumer's DRAW_LINE handler now signals
- // DrainCond on the fetch_sub that takes DrawCounter to zero;
- // see the case in RThreadEntry. The slock around scond_wait is
- // POSIX-required even though we never write any shared state
- // while holding it -- the lock is what closes the missed-wakeup
- // race between checking DrawCounter and entering scond_wait.
+ // commands for this frame -- i.e. for DrawFinishCount to catch up
+ // to the producer-local DrawPushLocal. Replaces an old spin-yield
+ // loop (ssem_signal(WakeupSem) + retro_sleep repeatedly) with a
+ // condvar wait. The consumer's DRAW_LINE handler signals DrainCond
+ // on the completion that levels the two counters; see the case in
+ // RThreadEntry. The slock around scond_wait is POSIX-required even
+ // though we never write any shared state while holding it -- the
+ // lock is what closes the missed-wakeup race between checking the
+ // counters and entering scond_wait.
  //
  // The initial WakeupSem signal is still needed: it kicks the
  // consumer out of any ssem_wait it might be in on an empty
- // command queue, so progress on DrawCounter can resume.
- if (MDFN_UNLIKELY(DrawCounter.load(std::memory_order_acquire) != 0))
+ // command queue, so progress on DrawFinishCount can resume.
+ if (MDFN_UNLIKELY(DrawFinishCount.load(std::memory_order_acquire) != Prod.DrawPushLocal))
  {
   ssem_signal(WakeupSem);
   slock_lock(DrainLock);
-  while (DrawCounter.load(std::memory_order_acquire) != 0)
+  while (DrawFinishCount.load(std::memory_order_acquire) != Prod.DrawPushLocal)
    scond_wait(DrainCond, DrainLock);
   slock_unlock(DrainLock);
  }
@@ -3471,7 +3507,9 @@ void VDP2REND_DrawLine(const int vdp2_line, const uint32 crt_line, const bool fi
   if(espec->InterlaceOn)
    out_line = (out_line << 1) | espec->InterlaceField;
 
-  auto wdcq = DrawCounter.fetch_add(1, std::memory_order_release);
+  const uint32 wdcq = Prod.DrawPushLocal - DrawFinishCount.load(std::memory_order_acquire);
+  ++Prod.DrawPushLocal;
+  DrawPushCount.store(Prod.DrawPushLocal, std::memory_order_release);
   WWQ(COMMAND_DRAW_LINE, ((uint16)vdp2_line << 16) | out_line, field);
   //
   //
@@ -3508,7 +3546,7 @@ void VDP2REND_SetLayerEnableMask(uint64 mask)
 
 void VDP2REND_Write8_DB(uint32 A, uint16 DB)
 {
- //if(DrawCounter.load(std::memory_order_acquire) != 0)
+ //if(DrawFinishCount.load(std::memory_order_acquire) != Prod.DrawPushLocal)
   WWQ(COMMAND_WRITE8, A, DB);
  //else
  // MemW<uint8>(A, DB);
@@ -3516,7 +3554,7 @@ void VDP2REND_Write8_DB(uint32 A, uint16 DB)
 
 void VDP2REND_Write16_DB(uint32 A, uint16 DB)
 {
- //if(DrawCounter.load(std::memory_order_acquire) != 0)
+ //if(DrawFinishCount.load(std::memory_order_acquire) != Prod.DrawPushLocal)
   WWQ(COMMAND_WRITE16, A, DB);
  //else
  // MemW<uint16>(A, DB);
@@ -3524,7 +3562,7 @@ void VDP2REND_Write16_DB(uint32 A, uint16 DB)
 
 void VDP2REND_StateAction(StateMem* sm, const unsigned load, const bool data_only, uint16 (&rr)[0x100], uint16 (&cr)[2048], uint16 (&vr)[262144])
 {
- while(MDFN_UNLIKELY(WQ_InCount.load(std::memory_order_acquire) != 0))
+ while(MDFN_UNLIKELY(WQ_PopCount.load(std::memory_order_acquire) != Prod.PushLocal))
  {
   ssem_signal(WakeupSem);
   retro_sleep(1);

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -3115,6 +3115,7 @@ enum
 {
  COMMAND_WRITE8 = 0,
  COMMAND_WRITE16,
+ COMMAND_WRITE16_BURST,	// Arg32 = base B-bus address, Arg16 = n16 | (add_mode << 13); n16 uint16 payload words follow in BurstBuf.
 
  COMMAND_DRAW_LINE,
 
@@ -3134,6 +3135,18 @@ struct WQ_Entry
 };
 
 static std::array<WQ_Entry, 0x80000> WQ;
+
+// Payload ring for COMMAND_WRITE16_BURST (DSP-DMA streaming a contiguous run of
+// 16-bit writes into the VDP2 register/RAM window). Single-producer (emulator
+// thread, in DMAInstr) / single-consumer (RThreadEntry). It carries no atomic of
+// its own beyond BurstPopCount: the producer fills the payload slots *before* the
+// WWQ() that publishes the burst command, so that WWQ's release-store on
+// WQ_PushCount also publishes these writes, and the consumer's acquire-load makes
+// them visible before it dispatches the burst. Sized large enough that the
+// occupancy check below never realistically blocks (one max burst is 512 words).
+static constexpr uint32 BurstBufSize = 1u << 20;
+static constexpr uint32 BurstBufMask = BurstBufSize - 1;
+static std::array<uint16, BurstBufSize> BurstBuf;
 // SPSC queue state. Each atomic is written by exactly one thread (release-store)
 // and read by the other (acquire-load); live queue depth is recovered by
 // subtraction, avoiding the cross-thread RMW that bounced the cache line.
@@ -3149,6 +3162,7 @@ alignas(64) static std::atomic_uint_least32_t WQ_PushCount;     // producer-writ
 alignas(64) static std::atomic_uint_least32_t WQ_PopCount;      // consumer-written
 alignas(64) static std::atomic_uint_least32_t DrawFinishCount;  // consumer-written
 alignas(64) static std::atomic_uint_least32_t DrawPushCount;    // producer-written
+alignas(64) static std::atomic_uint_least32_t BurstPopCount;    // consumer-written; cumulative uint16 words drained from BurstBuf
 struct alignas(64) ProducerState
 {
  size_t WritePos;
@@ -3156,12 +3170,15 @@ struct alignas(64) ProducerState
  uint32 DrawPushLocal;    // total VDP2REND_DrawLine pushes
  uint32 WQ_PopCached;     // last-seen WQ_PopCount; refreshed only when the queue
                           // appears full (huge queue, so basically never)
+ uint32 BurstWritePos;    // cumulative uint16 words written to BurstBuf
+ uint32 BurstPopCached;   // last-seen BurstPopCount; refreshed only when BurstBuf appears full
 };
 struct alignas(64) ConsumerState
 {
  size_t ReadPos;
  uint32 PopLocal;         // total WQ pops
  uint32 DrawFinishLocal;  // total DrawLine completions
+ uint32 BurstReadPos;     // cumulative uint16 words drained from BurstBuf
 };
 static ProducerState Prod;
 static ConsumerState Cons;
@@ -3255,6 +3272,22 @@ static void/*int*/ RThreadEntry(void* data)
 	MemW<uint16>(wqe->Arg32, wqe->Arg16);
 	break;
 
+   case COMMAND_WRITE16_BURST:
+	{
+	 const uint32 n16 = wqe->Arg16 & 0x1FFF;
+	 const uint32 stride = (1u << (wqe->Arg16 >> 13)) &~ 1u;
+	 uint32 a = wqe->Arg32;
+
+	 for(uint32 i = 0; i < n16; i++)
+	 {
+	  MemW<uint16>(a, BurstBuf[(Cons.BurstReadPos + i) & BurstBufMask]);
+	  a += stride;
+	 }
+	 Cons.BurstReadPos += n16;
+	 BurstPopCount.store(Cons.BurstReadPos, std::memory_order_release);
+	}
+	break;
+
    case COMMAND_DRAW_LINE:
 	//for(unsigned i = 0; i < 2; i++)
 	DrawLine((uint16)wqe->Arg32, wqe->Arg32 >> 16, wqe->Arg16);
@@ -3322,6 +3355,7 @@ void VDP2REND_Init(const bool IsPAL, const uint64 affinity)
  WQ_PopCount.store(0, std::memory_order_release);
  DrawFinishCount.store(0, std::memory_order_release);
  DrawPushCount.store(0, std::memory_order_release);
+ BurstPopCount.store(0, std::memory_order_release);
  WakeupSem = ssem_new(0);
  DrainLock = slock_new();
  DrainCond = scond_new();
@@ -3558,6 +3592,27 @@ void VDP2REND_Write16_DB(uint32 A, uint16 DB)
   WWQ(COMMAND_WRITE16, A, DB);
  //else
  // MemW<uint16>(A, DB);
+}
+
+// DSP-DMA burst of n16 16-bit writes: words[i] -> (base + i * ((1<<add_mode)&~1)).
+// Equivalent to n16 successive VDP2REND_Write16_DB() calls but collapses them to a
+// single queue command + a bulk payload copy. n16 <= 512, add_mode <= 7.
+void VDP2REND_WriteBurst16_DB(uint32 base, uint32 n16, uint32 add_mode, const uint16* words)
+{
+ // Reserve n16 contiguous (mod BurstBufSize) payload slots, spin-sleeping if the
+ // consumer hasn't drained enough yet (mirrors WWQ's queue-full handling).
+ while(MDFN_UNLIKELY((Prod.BurstWritePos - Prod.BurstPopCached) > (BurstBufSize - n16)))
+ {
+  Prod.BurstPopCached = BurstPopCount.load(std::memory_order_acquire);
+  if((Prod.BurstWritePos - Prod.BurstPopCached) > (BurstBufSize - n16))
+   retro_sleep(1);
+ }
+
+ for(uint32 i = 0; i < n16; i++)
+  BurstBuf[(Prod.BurstWritePos + i) & BurstBufMask] = words[i];
+ Prod.BurstWritePos += n16;
+
+ WWQ(COMMAND_WRITE16_BURST, base, (uint16)(n16 | (add_mode << 13)));
 }
 
 void VDP2REND_StateAction(StateMem* sm, const unsigned load, const bool data_only, uint16 (&rr)[0x100], uint16 (&cr)[2048], uint16 (&vr)[262144])

--- a/mednafen/ss/vdp2_render.cpp
+++ b/mednafen/ss/vdp2_render.cpp
@@ -2536,17 +2536,18 @@ static void T_MixIt(uint32* target, const unsigned vdp2_line, const unsigned w, 
    const uint32 rgb_tmp = pix >> PIX_RGB_SHIFT;
    int32 rt, gt, bt;
 
+   // Magnitude test (not bit-test) so the compiler emits csel instead of tst+branch.
    rt = ColorOffs[sel][0] + (rgb_tmp & 0x000000FF);
    if(rt < 0) rt = 0;
-   if(rt & 0x00000100) rt = 0x000000FF;
+   if(rt > 0x000000FF) rt = 0x000000FF;
 
    gt = ColorOffs[sel][1] + (rgb_tmp & 0x0000FF00);
    if(gt < 0) gt = 0;
-   if(gt & 0x00010000) gt = 0x0000FF00;
+   if(gt > 0x0000FF00) gt = 0x0000FF00;
 
    bt = ColorOffs[sel][2] + (rgb_tmp & 0x00FF0000);
    if(bt < 0) bt = 0;
-   if(bt & 0x01000000) bt = 0x00FF0000;
+   if(bt > 0x00FF0000) bt = 0x00FF0000;
 
    pix = (uint32)pix | ((uint64)(uint32)(rt | gt | bt) << PIX_RGB_SHIFT);
   }

--- a/mednafen/ss/vdp2_render.h
+++ b/mednafen/ss/vdp2_render.h
@@ -55,6 +55,7 @@ void VDP2REND_DrawLine(int vdp2_line, const uint32 crt_line, const bool field);
 
 void VDP2REND_Write8_DB(uint32 A, uint16 DB) MDFN_HOT;
 void VDP2REND_Write16_DB(uint32 A, uint16 DB) MDFN_HOT;
+void VDP2REND_WriteBurst16_DB(uint32 base, uint32 n16, uint32 add_mode, const uint16* words) MDFN_HOT;
 
 
 #endif


### PR DESCRIPTION
dd105f0 scu/vdp2: collapse per-halfword DSP-DMA VDP2 writes 
64a07ab scu_dsp: tail-chain handlers to drop the per-cycle dispatcher frame 
81b1a4c scu_dsp: thread DSPS* through dispatch ABI to elide per-handler adrp+add 
b7dcedc ss/scu_dsp: force-inline per-step helpers under -Os 
2d4faf9 vdp2_render: split SPSC counters to eliminate contended atomic RMWs 
381d0af sh7095: reorder MA_until past MM_until to break STLF-stalled ldp 
7adbadb vdp2_render: replace 1000-nop busywait with yield on aarch64 
40b347d vdp2_render: branchless color-offset clamp in T_MixIt 
82fde86 ss: replace event linked list with SoA + SIMD min-reduction 
be1fef6 Make DoIDIF_NI a member function of SH7095 
1929b64 ss/scsp: collapse SoundStackDelayer rotation into 64-bit packed shift 
f26396b ss/scsp: skip DSP steps with no observable side effects 
1cf8847 ss/scsp: pre-decode DSP MPROG on dirty, drop per-step bit-extract spills 
c031174 Makefile: accept LTO=, make 1 the default 
94765b0 ss/sh7095: fuse hot op pairs/triplets and NOP delay slots 
d9cc15e Reinstate mednafen INLINE as FORCE_INLINE 
4af42d6 .gitignore .data and .old profile records 
2cdfacc build: track header dependencies via -MMD -MP 