### PR TITLE
Audio fixes

### DIFF
--- a/mednafen/ss/scsp.h
+++ b/mednafen/ss/scsp.h
@@ -274,7 +274,6 @@ class SS_SCSP
   uint8 TRA;	// 7 bits, MDEC_CT added at runtime
   uint8 YSEL;	// 2 bits
   uint32 flags;	// see DSPF_*
-  uint8 hazard_next;	// DSPH_* bitmask describing the step N -> step N+1 edge
   uint8 reads;	// DSPR_* bitmask of carried state this step consumes
   uint8 writes;	// DSPW_* bitmask of carried state this step produces
   uint8 live;	// 0 = dead step, RunDSP skips it
@@ -302,16 +301,10 @@ class SS_SCSP
   DSPF_TWT    = 1u << 17
  };
 
- // Carried-state read/write bitmasks. Same bit positions for parallel R/W;
- // distinct prefixes for clarity at use sites.
+ // Carried-state write bitmask, plus the one read-side bit the liveness pass needs.
  enum
  {
-  DSPR_SFT  = 1u << 0,	// SFT_REG consumed (any of EWT/TWT/FRCL/ADRL/MWT or BSEL)
-  DSPR_FRC  = 1u << 1,	// FRC_REG consumed (YSEL == 0)
-  DSPR_Y    = 1u << 2,	// Y_REG consumed (YSEL == 2 or 3)
-  DSPR_ADRS = 1u << 3,	// ADRS_REG consumed (ADRGB)
-  DSPR_TEMP = 1u << 4,	// TEMP[TRA] value consumed (XSEL == 0 or BSEL == 0)
-  DSPR_MEMS = 1u << 5,	// MEMS[IRA] consumed ((IRA & 0x20) == 0)
+  DSPR_SFT  = 1u << 0,	// step consumes SFT_REG (any of EWT/TWT/FRCL/ADRL/MWT or BSEL)
 
   DSPW_SFT   = 1u << 0,	// SFT_REG written (always)
   DSPW_FRC   = 1u << 1,	// FRC_REG written (FRCL)
@@ -321,13 +314,6 @@ class SS_SCSP
   DSPW_MEMS  = 1u << 5,	// MEMS[IWA] written (IWT)
   DSPW_EFREG = 1u << 6,	// EFREG[EWA] written (EWT)
   DSPW_RAM   = 1u << 7	// RAM pipeline state advanced (MRT or MWT)
- };
-
- // Hazard annotations for the step N -> step N+1 edge (hazard_next[N]).
- enum
- {
-  DSPH_RAW  = 1u << 0,	// step N+1 reads carried state step N produced (blocks reordering/fusion across the edge)
-  DSPH_PIPE = 1u << 1	// step N triggered an MRT/MWT; step N+1's body services that RAM op, so it must execute
  };
 
  struct DSPS

--- a/mednafen/ss/scsp.h
+++ b/mednafen/ss/scsp.h
@@ -274,7 +274,7 @@ class SS_SCSP
   uint8 TRA;	// 7 bits, MDEC_CT added at runtime
   uint8 YSEL;	// 2 bits
   uint32 flags;	// see DSPF_*
-  uint8 hazard_next;	// bit 0: step N+1 RAW-depends on step N
+  uint8 hazard_next;	// DSPH_* bitmask describing the step N -> step N+1 edge
   uint8 reads;	// DSPR_* bitmask of carried state this step consumes
   uint8 writes;	// DSPW_* bitmask of carried state this step produces
   uint8 live;	// 0 = dead step, RunDSP skips it
@@ -321,6 +321,13 @@ class SS_SCSP
   DSPW_MEMS  = 1u << 5,	// MEMS[IWA] written (IWT)
   DSPW_EFREG = 1u << 6,	// EFREG[EWA] written (EWT)
   DSPW_RAM   = 1u << 7	// RAM pipeline state advanced (MRT or MWT)
+ };
+
+ // Hazard annotations for the step N -> step N+1 edge (hazard_next[N]).
+ enum
+ {
+  DSPH_RAW  = 1u << 0,	// step N+1 reads carried state step N produced (blocks reordering/fusion across the edge)
+  DSPH_PIPE = 1u << 1	// step N triggered an MRT/MWT; step N+1's body services that RAM op, so it must execute
  };
 
  struct DSPS

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -1207,15 +1207,7 @@ void SS_SCSP::DecodeMPROG(void)
   f |= ((instr >> 55) & 1) ? DSPF_TWT    : 0;
   s.flags = f;
 
-  uint8 reads = 0;
-  if(f & (DSPF_EWT | DSPF_TWT | DSPF_FRCL | DSPF_ADRL | DSPF_MWT | DSPF_BSEL))
-   reads |= DSPR_SFT;
-  if(s.YSEL == 0)                            reads |= DSPR_FRC;
-  if(s.YSEL == 2 || s.YSEL == 3)             reads |= DSPR_Y;
-  if(f & DSPF_ADRGB)                         reads |= DSPR_ADRS;
-  if(!(f & DSPF_XSEL) || !(f & DSPF_BSEL))   reads |= DSPR_TEMP;
-  if(!(s.IRA & 0x20))                        reads |= DSPR_MEMS;
-  s.reads = reads;
+  s.reads = (f & (DSPF_EWT | DSPF_TWT | DSPF_FRCL | DSPF_ADRL | DSPF_MWT | DSPF_BSEL)) ? DSPR_SFT : 0;
 
   uint8 writes = DSPW_SFT;
   if(f & DSPF_FRCL)                  writes |= DSPW_FRC;
@@ -1227,33 +1219,7 @@ void SS_SCSP::DecodeMPROG(void)
   if(f & (DSPF_MRT | DSPF_MWT))      writes |= DSPW_RAM;
   s.writes = writes;
 
-  s.hazard_next = 0;	// filled in by hazard pass
   s.live = 1;		// filled in by liveness pass
- }
-
- // Hazard pass: annotate each step N -> step N+1 edge (wrapping at the sample
- // boundary -- carried state and the RAM read/write pipeline persist into the
- // next RunDSP).  DSPH_RAW marks a read-after-write on carried state (a future
- // fusion/reorder pass must not cross it); DSPH_PIPE marks that step N kicked off
- // a RAM op whose service happens in step N+1's body.
- for(unsigned step = 0; step < 128; step++)
- {
-  const DSPStep& cur = DSP.MPROG_Decoded[step];
-  const DSPStep& nxt = DSP.MPROG_Decoded[(step + 1) & 0x7F];
-  uint8 haz = 0;
-
-  if((nxt.reads & DSPR_SFT) ||
-     ((cur.writes & DSPW_FRC)  && (nxt.reads & DSPR_FRC))  ||
-     ((cur.writes & DSPW_Y)    && (nxt.reads & DSPR_Y))    ||
-     ((cur.writes & DSPW_ADRS) && (nxt.reads & DSPR_ADRS)) ||
-     ((cur.writes & DSPW_TEMP) && (nxt.reads & DSPR_TEMP) && cur.TWA == nxt.TRA) ||
-     ((cur.writes & DSPW_MEMS) && (nxt.reads & DSPR_MEMS) && cur.IWA == (nxt.IRA & 0x1F)))
-   haz |= DSPH_RAW;
-
-  if(cur.writes & DSPW_RAM)
-   haz |= DSPH_PIPE;
-
-  DSP.MPROG_Decoded[step].hazard_next = haz;
  }
 
  // Liveness pass: a step is dead if its only observable writes are SFT_REG and/or
@@ -1278,15 +1244,16 @@ void SS_SCSP::DecodeMPROG(void)
   DSP.MPROG_Decoded[step].live = (has_other_writes || sft_observed || inputs_observed) ? 1 : 0;
  }
 
- // A RAM op triggered by step N (DSPH_PIPE) is not serviced in that step:
+ // A RAM op triggered by step N (MRT/MWT) is not serviced in that step:
  // RWAddr/ReadPending/WritePending are latched at its tail, and step N+1's body
  // commits it (RAM read -> ReadValue, or RAM <- WriteValue) *before* doing its
  // own IWT.  If step N+1 were elided, that commit would slip onto a later live
  // step, past the IWT consumer at N+2, which would then latch a stale ReadValue.
- // So a DSPH_PIPE edge pins the successor live regardless of its own outputs.
+ // So pin the successor live, wrapping at the sample boundary (the RAM pipeline
+ // persists into the next RunDSP).
  for(unsigned step = 0; step < 128; step++)
  {
-  if(DSP.MPROG_Decoded[step].hazard_next & DSPH_PIPE)
+  if(DSP.MPROG_Decoded[step].flags & (DSPF_MRT | DSPF_MWT))
    DSP.MPROG_Decoded[(step + 1) & 0x7F].live = 1;
  }
 

--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -1231,22 +1231,27 @@ void SS_SCSP::DecodeMPROG(void)
   s.live = 1;		// filled in by liveness pass
  }
 
- // Hazard pass: hazard_next[N] bit 0 = "step N+1 RAW-depends on step N"
- for(unsigned step = 0; step < 127; step++)
+ // Hazard pass: annotate each step N -> step N+1 edge (wrapping at the sample
+ // boundary -- carried state and the RAM read/write pipeline persist into the
+ // next RunDSP).  DSPH_RAW marks a read-after-write on carried state (a future
+ // fusion/reorder pass must not cross it); DSPH_PIPE marks that step N kicked off
+ // a RAM op whose service happens in step N+1's body.
+ for(unsigned step = 0; step < 128; step++)
  {
   const DSPStep& cur = DSP.MPROG_Decoded[step];
-  const DSPStep& nxt = DSP.MPROG_Decoded[step + 1];
+  const DSPStep& nxt = DSP.MPROG_Decoded[(step + 1) & 0x7F];
   uint8 haz = 0;
 
-  if(nxt.reads & DSPR_SFT)                                         haz = 1;
-  else if((cur.writes & DSPW_FRC)  && (nxt.reads & DSPR_FRC))      haz = 1;
-  else if((cur.writes & DSPW_Y)    && (nxt.reads & DSPR_Y))        haz = 1;
-  else if((cur.writes & DSPW_ADRS) && (nxt.reads & DSPR_ADRS))     haz = 1;
-  else if((cur.writes & DSPW_TEMP) && (nxt.reads & DSPR_TEMP) && cur.TWA == nxt.TRA)
-                                                                   haz = 1;
-  else if((cur.writes & DSPW_MEMS) && (nxt.reads & DSPR_MEMS) && cur.IWA == (nxt.IRA & 0x1F))
-                                                                   haz = 1;
-  else if(cur.writes & DSPW_RAM)                                   haz = 1;
+  if((nxt.reads & DSPR_SFT) ||
+     ((cur.writes & DSPW_FRC)  && (nxt.reads & DSPR_FRC))  ||
+     ((cur.writes & DSPW_Y)    && (nxt.reads & DSPR_Y))    ||
+     ((cur.writes & DSPW_ADRS) && (nxt.reads & DSPR_ADRS)) ||
+     ((cur.writes & DSPW_TEMP) && (nxt.reads & DSPR_TEMP) && cur.TWA == nxt.TRA) ||
+     ((cur.writes & DSPW_MEMS) && (nxt.reads & DSPR_MEMS) && cur.IWA == (nxt.IRA & 0x1F)))
+   haz |= DSPH_RAW;
+
+  if(cur.writes & DSPW_RAM)
+   haz |= DSPH_PIPE;
 
   DSP.MPROG_Decoded[step].hazard_next = haz;
  }
@@ -1271,6 +1276,18 @@ void SS_SCSP::DecodeMPROG(void)
   const bool inputs_observed      = cur_writes_inputs && nxt_preserves_inputs && nxt_uses_inputs;
 
   DSP.MPROG_Decoded[step].live = (has_other_writes || sft_observed || inputs_observed) ? 1 : 0;
+ }
+
+ // A RAM op triggered by step N (DSPH_PIPE) is not serviced in that step:
+ // RWAddr/ReadPending/WritePending are latched at its tail, and step N+1's body
+ // commits it (RAM read -> ReadValue, or RAM <- WriteValue) *before* doing its
+ // own IWT.  If step N+1 were elided, that commit would slip onto a later live
+ // step, past the IWT consumer at N+2, which would then latch a stale ReadValue.
+ // So a DSPH_PIPE edge pins the successor live regardless of its own outputs.
+ for(unsigned step = 0; step < 128; step++)
+ {
+  if(DSP.MPROG_Decoded[step].hazard_next & DSPH_PIPE)
+   DSP.MPROG_Decoded[(step + 1) & 0x7F].live = 1;
  }
 
  DSP.MPROG_Dirty = false;


### PR DESCRIPTION
82549e9 ss/scsp: drop dormant DSP hazard table, fold MRT/MWT pin into liveness
9988238 ss/scsp: don't elide the DSP step that services an MRT/MWT