### PR TITLE
Optimizations 2

### DIFF
--- a/mednafen/ss/scsp.inc
+++ b/mednafen/ss/scsp.inc
@@ -1374,7 +1374,19 @@ INLINE void SS_SCSP::RunDSP(void)
   }
 
   const int32_t INPUTS = sign_x_to_s32(24, DSP.INPUTS);
-  const uint16_t Y_SEL_Inputs[4] = { DSP.FRC_REG, DSP.COEF[s.CRA], (uint16_t)((DSP.Y_REG >> 11) & 0x1FFF), (uint16_t)((DSP.Y_REG >> 4) & 0x0FFF) };
+  //
+  // Y multiplicand selector.  YSEL is a 2-bit field; expressing it as a
+  // runtime-indexed local array makes the compiler materialize a 4-entry
+  // stack table and read back through `ldrh [sp, idx, lsl #1]` with a
+  // variable index — a store-to-load forwarding stall, the single hottest
+  // line in RunDSP.  A csel chain keeps the four candidates in registers.
+  const uint16_t y_frc   = DSP.FRC_REG;
+  const uint16_t y_coef  = DSP.COEF[s.CRA];
+  const uint16_t y_yhi   = (DSP.Y_REG >> 11) & 0x1FFF;
+  const uint16_t y_ylo   = (DSP.Y_REG >>  4) & 0x0FFF;
+  const uint16_t y_lopr  = (s.YSEL & 1) ? y_coef : y_frc;
+  const uint16_t y_hipr  = (s.YSEL & 1) ? y_ylo  : y_yhi;
+  const uint16_t y_input = (s.YSEL & 2) ? y_hipr : y_lopr;
   //
   //
   //
@@ -1401,20 +1413,19 @@ INLINE void SS_SCSP::RunDSP(void)
   //
   if(f & DSPF_FRCL)
   {
-   const unsigned F_SEL_Inputs[2] = { (unsigned)(ShifterOutput >> 11), (unsigned)(ShifterOutput & 0xFFF) };
-
-   DSP.FRC_REG = F_SEL_Inputs[shft0 & shft1];
+   // F_SEL: shft0&shft1 picks low-12 vs high-13 bits of ShifterOutput.
+   DSP.FRC_REG = (shft0 & shft1) ? (unsigned)(ShifterOutput & 0xFFF)
+                                 : (unsigned)(ShifterOutput >> 11);
   }
   //
   //
   {
    const int32_t TEMP = sign_x_to_s32(24, DSP.TEMP[TEMPReadAddr]);
-   const uint32_t SGA_Inputs[2] = { (uint32_t)TEMP, DSP.SFT_REG };
-   const int32_t X_SEL_Inputs[2] = { TEMP, INPUTS };
-   const uint32_t Product = ((int64_t)sign_x_to_s32(13, Y_SEL_Inputs[s.YSEL]) * X_SEL_Inputs[(f >> 16) & 1]) >> 12;
-   uint32_t SGAOutput;
-
-   SGAOutput = SGA_Inputs[(f >> 3) & 1];
+   // X_SEL: DSPF_XSEL picks INPUTS over TEMP for the multiplier's X side.
+   const int32_t x_input = (f & DSPF_XSEL) ? INPUTS : TEMP;
+   const uint32_t Product = ((int64_t)sign_x_to_s32(13, y_input) * x_input) >> 12;
+   // SGA: DSPF_BSEL picks SFT_REG over TEMP for the SGA add input.
+   uint32_t SGAOutput = (f & DSPF_BSEL) ? DSP.SFT_REG : (uint32_t)TEMP;
 
    if(f & DSPF_NEGB)
     SGAOutput = -SGAOutput;
@@ -1485,9 +1496,10 @@ INLINE void SS_SCSP::RunDSP(void)
   //
   if(f & DSPF_ADRL)
   {
-   const uint16_t A_SEL_Inputs[2] = { /*INPUTS is sign-extended above */ (uint16_t)((INPUTS >> 16) & 0xFFF), (uint16_t)(ShifterOutput >> 12) };
-
-   DSP.ADRS_REG = A_SEL_Inputs[shft0 & shft1];
+   // A_SEL: shft0&shft1 picks ShifterOutput>>12 vs INPUTS>>16. INPUTS is
+   // sign-extended above; both branches truncate to 12 bits.
+   DSP.ADRS_REG = (shft0 & shft1) ? (uint16_t)(ShifterOutput >> 12)
+                                  : (uint16_t)((INPUTS >> 16) & 0xFFF);
   }
  }
 

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -2167,9 +2167,15 @@ INLINE void SH7095::Cache_AssocPurge(const uint32_t A)
  cent->Tag[3] |= (ATM == cent->Tag[3]);
 }
 
+#if defined(__SSE2__)
+#include <emmintrin.h>
+#elif defined(__aarch64__)
+#include <arm_neon.h>
+#endif
+
 INLINE int SH7095::Cache_FindWay(CacheEntry* const cent, const uint32_t ATM)
 {
-#if defined(HAVE_SSE2_INTRINSICS)
+#if defined(__SSE2__)
  __m128i atm = _mm_set1_epi32(ATM);
  __m128i v1234 = _mm_setr_epi32(1, 2, 3, 4);
  __m128i tmp;
@@ -2180,6 +2186,14 @@ INLINE int SH7095::Cache_FindWay(CacheEntry* const cent, const uint32_t ATM)
  tmp = _mm_max_epi16(tmp, _mm_shuffle_epi32(tmp, (1 << 0) | (0 << 2)));
 
  return _mm_cvtsi128_si32(tmp) - 1;
+#elif defined(__aarch64__)
+ // 4-way tag match in 5 NEON ops, replacing 4 dependent csels via cmov_eq_thing.
+ // vmaxvq_u32 does horizontal max across the 128-bit register in one instruction.
+ const uint32x4_t atm   = vdupq_n_u32(ATM);
+ const uint32x4_t v1234 = { 1u, 2u, 3u, 4u };
+ const uint32x4_t tags  = vld1q_u32(cent->Tag);
+ const uint32x4_t hits  = vandq_u32(vceqq_u32(tags, atm), v1234);
+ return (int)vmaxvq_u32(hits) - 1;
 #else
  int way_match = -1;
 

--- a/mednafen/ss/sound.cpp
+++ b/mednafen/ss/sound.cpp
@@ -325,7 +325,14 @@ static MDFN_FASTCALL uint16_t SoundCPU_BusReadInstr(uint32_t A)
  //if(MDFN_UNLIKELY(SoundCPU.timestamp >= next_scsp_time))
  // RunSCSP();
 
- SCSP.RW<uint16_t, false>(A & 0x1FFFFF, ret);
+ // Fast path: instruction fetch goes to sound RAM (0x000000-0x07FFFF).
+ // The 68K can't sensibly execute from the mirror region or SCSP registers,
+ // so fall back to SCSP.RW only for the unlikely pathological case (which
+ // preserves its existing open-bus-returns-0 / register-read behavior).
+ if(MDFN_LIKELY(A < 0x80000))
+  ret = SCSP.GetRAMPtr()[A >> 1];
+ else
+  SCSP.RW<uint16_t, false>(A & 0x1FFFFF, ret);
 
  SoundCPU.timestamp += 2;
 


### PR DESCRIPTION
9e5c094 ss/sh7095: vectorize Cache_FindWay tag match (SSE2/NEON)
3e5818e ss/scsp: replace runtime-indexed DSP step selectors with csel chain
aa65854 ss/sound: fast-path 68K instruction fetch from sound RAM