### PR TITLE
ss: add progressive deinterlace

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -37,6 +37,7 @@
 #include "mednafen/ss/smpc.h"
 #include "mednafen/ss/stvio.h"
 #include "mednafen/ss/vdp1.h"
+#include "mednafen/ss/vdp2_deinterlace.h"
 /* vdp2.h's one entry point used here is forward-declared below
  * to keep this TU's include surface light -- vdp2.h would
  * transitively pull in ss.h's full event-system surface for a
@@ -141,7 +142,7 @@ extern MDFNGI EmulatedSS;
 /* Local forward decl for the single VDP2 entry point this TU
  * reaches into.  See the include block above for why vdp2.h isn't
  * pulled in directly. */
-extern void VDP2_SetDeinterlaceOff(bool off);
+extern void VDP2_SetDeinterlaceMode(unsigned mode);
 
 #ifdef NEED_DEINTERLACER
 static bool PrevInterlaced;
@@ -532,23 +533,18 @@ static void check_variables(bool startup)
    var.key = "beetle_saturn_deinterlacer";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      // The "off" mode pairs DEINT_OFF on the deinterlacer (which then
-      // does nothing) with VDP2_SetDeinterlaceOff(true) on the VDP2
-      // renderer side, which causes each rendered scanline to also be
-      // memcpy'd to the opposite-field row of the libretro surface.
-      // Every emulated frame thus produces a stable, full-resolution
-      // progressive image. All other modes leave the renderer in its
-      // default single-field-per-frame behaviour and let the
-      // deinterlacer combine fields after the fact.
       const bool off = (strcmp(var.value, "off") == 0);
-      VDP2_SetDeinterlaceOff(off);
+      const bool progressive = (strcmp(var.value, "progressive") == 0);
+
+      VDP2_SetDeinterlaceMode(progressive ? VDP2_DEINT_PROGRESSIVE :
+            (off ? VDP2_DEINT_OFF : VDP2_DEINT_NORMAL));
 
 #ifdef NEED_DEINTERLACER
       /* The 'deint' instance is itself #ifdef NEED_DEINTERLACER (declared
        * at file scope above), as are every other Deinterlacer_* call in
        * this TU (Init, ClearState, Process, GetType, Cleanup).  This
        * setting-handler chain was the lone exception, breaking the
-       * NEED_DEINTERLACER=0 build.  VDP2_SetDeinterlaceOff stays
+       * NEED_DEINTERLACER=0 build.  VDP2_SetDeinterlaceMode stays
        * outside the gate -- VDP2 is the GPU subsystem and independent
        * of the SW deinterlacer. */
       if (strcmp(var.value, "bob") == 0)
@@ -557,7 +553,7 @@ static void check_variables(bool startup)
          Deinterlacer_SetType(&deint, DEINT_BOB_OFFSET);
       else if (strcmp(var.value, "fastmad") == 0)
          Deinterlacer_SetType(&deint, DEINT_FASTMAD);
-      else if (off)
+      else if (off || progressive)
          Deinterlacer_SetType(&deint, DEINT_OFF);
       else
          Deinterlacer_SetType(&deint, DEINT_WEAVE);

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -441,7 +441,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "beetle_saturn_deinterlacer",
       "Deinterlace Method",
       NULL,
-      "How to combine the two fields of an interlaced signal. 'Weave' shows both the current and previous field together on every frame for full vertical resolution, with combing visible on moving content. 'Bob' shows only the current field, halved in height -- no comb, but half the vertical resolution. 'Bob (Offset)' shows only the current field doubled into full surface height with a one-line offset between fields; preserves the libretro output resolution while giving Bob-style smooth motion. 'FastMAD (Motion Adaptive)' does per-pixel motion detection between the current frame and two frames ago, weaving where the picture is still and interpolating where motion was detected; much higher CPU cost than the other modes but eliminates combing on motion while preserving full resolution where the picture is still. 'Off' has the VDP2 renderer fill both rows of every (even,odd) pair every emulated frame with current-frame content; full resolution, no comb on motion, but doubles the per-frame surface write work compared to the other modes.",
+      "How to combine the two fields of an interlaced signal. 'Weave' shows both the current and previous field together on every frame for full vertical resolution, with combing visible on moving content. 'Bob' shows only the current field, halved in height -- no comb, but half the vertical resolution. 'Bob (Offset)' shows only the current field doubled into full surface height with a one-line offset between fields; preserves the libretro output resolution while giving Bob-style smooth motion. 'FastMAD (Motion Adaptive)' does per-pixel motion detection between the current frame and two frames ago, weaving where the picture is still and interpolating where motion was detected; much higher CPU cost than the other modes but eliminates combing on motion while preserving full resolution where the picture is still. 'Progressive' renders both interlaced fields during the same emulated frame, writing field 0 to even rows and field 1 to odd rows for full-height output. 'Off' has the VDP2 renderer fill both rows of every (even,odd) pair every emulated frame with current-frame content; full resolution, no comb on motion, but doubles the per-frame surface write work compared to the other modes.",
       NULL,
       "video",
       {
@@ -449,6 +449,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "bob",        "Bob" },
          { "bob_offset", "Bob (Offset)" },
          { "fastmad",    "FastMAD (Motion Adaptive)" },
+         { "progressive", "Progressive" },
          { "off",        "Off" },
          { NULL, NULL },
       },

--- a/mednafen/ss/vdp1.c
+++ b/mednafen/ss/vdp1.c
@@ -124,6 +124,13 @@ static uint32_t InstantDrawSanityLimit; // ss_horrible_hacks
 uint16_t VDP1_VRAM[0x40000];
 uint16_t VDP1_FB[2][0x20000];
 
+/* Alternate framebuffer for the complementary VDP1 double-interlace field.
+ * Progressive output uses it so VDP2 can composite each output line with
+ * the matching VDP1 field: even source rows stay in FB, odd rows go here. */
+uint16_t VDP1_AltFB[2][0x20000];
+uint16_t* VDP1_AltFBDrawWhichPtr;
+bool VDP1_AltFieldCapture = false;
+
 // Side-buffer for "improved mesh transparency" mode. When VDP1_MeshImproved
 // is true, VDP1 mesh-bit primitives write their colour here (with MSB
 // set as the "mesh pixel present" marker) instead of the main FB.
@@ -138,6 +145,8 @@ uint16_t VDP1_FB[2][0x20000];
 // per-frame clear matches the game's intent for the main framebuffer.
 uint16_t VDP1_MeshFB[2][0x20000];
 uint16_t* VDP1_MeshFBDrawWhichPtr;
+uint16_t VDP1_AltMeshFB[2][0x20000];
+uint16_t* VDP1_AltMeshFBDrawWhichPtr;
 
 // Module-level toggle for the "improved mesh transparency" mode.
 // Read by PlotPixel in vdp1_common.h when its MeshEn template
@@ -147,6 +156,11 @@ bool VDP1_MeshImproved = false;
 void VDP1_SetMeshImproved(bool improved)
 {
  VDP1_MeshImproved = improved;
+}
+
+void VDP1_SetAltFieldCapture(bool enabled)
+{
+ VDP1_AltFieldCapture = enabled;
 }
 
 void VDP1_Init(void)
@@ -199,7 +213,10 @@ void VDP1_Reset(bool powering_up)
 
   for(unsigned fb = 0; fb < 2; fb++)
    for(unsigned i = 0; i < 0x20000; i++)
+   {
     VDP1_FB[fb][i] = 0xFFFF;
+    VDP1_AltFB[fb][i] = 0xFFFF;
+   }
 
   memset(&VDP1_LineData, 0, sizeof(VDP1_LineData));
   memset(&VDP1_LineInnerData, 0, sizeof(VDP1_LineInnerData));
@@ -226,8 +243,11 @@ void VDP1_Reset(bool powering_up)
 
  FBDrawWhich = 0;
  VDP1_FBDrawWhichPtr = VDP1_FB[FBDrawWhich];
+ VDP1_AltFBDrawWhichPtr = VDP1_AltFB[FBDrawWhich];
  VDP1_MeshFBDrawWhichPtr = VDP1_MeshFB[FBDrawWhich];
+ VDP1_AltMeshFBDrawWhichPtr = VDP1_AltMeshFB[FBDrawWhich];
  memset(VDP1_MeshFB, 0, sizeof(VDP1_MeshFB));
+ memset(VDP1_AltMeshFB, 0, sizeof(VDP1_AltMeshFB));
  //SS_SetPhysMemMap(0x05C80000, 0x05CFFFFF, VDP1_FB[FBDrawWhich], sizeof(VDP1_FB[0]), true);
 
  FBManualPending = false;
@@ -876,15 +896,21 @@ void VDP1_SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_sta
     do
     {
      uint16_t* fbyptr;
+     uint16_t* afbyptr;
      uint16_t* mfbyptr;
+     uint16_t* amfbyptr;
      uint32_t x = EraseParams.x_start;
 
      fbyptr = &VDP1_FB[!FBDrawWhich][(y & 0xFF) << 9];
+     afbyptr = &VDP1_AltFB[!FBDrawWhich][(y & 0xFF) << 9];
      mfbyptr = &VDP1_MeshFB[!FBDrawWhich][(y & 0xFF) << 9];
+     amfbyptr = &VDP1_AltMeshFB[!FBDrawWhich][(y & 0xFF) << 9];
      if(EraseParams.rot8)
      {
       fbyptr += (y & 0x100);
+      afbyptr += (y & 0x100);
       mfbyptr += (y & 0x100);
+      amfbyptr += (y & 0x100);
      }
 
      count -= 8;
@@ -893,12 +919,14 @@ void VDP1_SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_sta
       for(unsigned sub = 0; sub < 8; sub++)
       {
        fbyptr[x & EraseParams.fb_x_mask] = EraseParams.fill_data;
+       afbyptr[x & EraseParams.fb_x_mask] = EraseParams.fill_data;
        // Clear the side-buffer in lockstep with the main FB so the
        // new draw side starts with no stale mesh pixels from the
        // previous frame. Mesh side-buffer always erases to 0
        // regardless of the game's chosen FB fill colour, since 0
        // is the "no mesh pixel here" marker.
        mfbyptr[x & EraseParams.fb_x_mask] = 0;
+       amfbyptr[x & EraseParams.fb_x_mask] = 0;
        x++;
       }
       count -= 8;
@@ -925,7 +953,9 @@ void VDP1_SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_sta
 
     FBDrawWhich = !FBDrawWhich;
     VDP1_FBDrawWhichPtr = VDP1_FB[FBDrawWhich];
+    VDP1_AltFBDrawWhichPtr = VDP1_AltFB[FBDrawWhich];
     VDP1_MeshFBDrawWhichPtr = VDP1_MeshFB[FBDrawWhich];
+    VDP1_AltMeshFBDrawWhichPtr = VDP1_AltMeshFB[FBDrawWhich];
 
     // Unconditionally clear the new draw side of VDP1_MeshFB. Game-driven erase
     // (VBErase, per-scanline GetLine erase) is gated on the game's VDP1_FBCR/
@@ -933,7 +963,10 @@ void VDP1_SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_sta
     // management. Mesh data is transient by nature - we always want a fresh
     // slate per frame, regardless of the game's main-FB persistence choices.
     if(VDP1_MeshImproved)
+    {
      memset(VDP1_MeshFBDrawWhichPtr, 0, sizeof(VDP1_MeshFB[0]));
+     memset(VDP1_AltMeshFBDrawWhichPtr, 0, sizeof(VDP1_AltMeshFB[0]));
+    }
 
     // On fb swap, copy CEF to BEF, clear CEF, and copy COPR to LOPR.
     EDSR = EDSR >> 1;
@@ -974,16 +1007,21 @@ void VDP1_SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_sta
  vbcdpending |= old_vb_status ^ vb_status;
 }
 
-bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w, uint32_t rot_x, uint32_t rot_y, uint32_t rot_xinc, uint32_t rot_yinc)
+bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, uint16_t* alt_buf, uint16_t* alt_mesh_buf, bool* alt_valid, unsigned w, uint32_t rot_x, uint32_t rot_y, uint32_t rot_xinc, uint32_t rot_yinc)
 {
  bool ret = false;
+ const bool read_alt = VDP1_AltFieldCapture && (VDP1_FBCR & VDP1_FBCR_DIE) && alt_buf && alt_mesh_buf;
+ if(alt_valid)
+  *alt_valid = read_alt;
  //
  //
  //
  if(VDP1_TVMR & VDP1_TVMR_ROTATE)
  {
   const uint16_t* fbptr = VDP1_FB[!FBDrawWhich];
+  const uint16_t* afbptr = VDP1_AltFB[!FBDrawWhich];
   const uint16_t* mfbptr = VDP1_MeshFB[!FBDrawWhich];
+  const uint16_t* amfbptr = VDP1_AltMeshFB[!FBDrawWhich];
 
   if(VDP1_TVMR & VDP1_TVMR_8BPP)
   {
@@ -996,6 +1034,11 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
     {
      buf[i] = 0;	// Not 0xFF00
      mesh_buf[i] = 0;
+     if(read_alt)
+     {
+      alt_buf[i] = 0;
+      alt_mesh_buf[i] = 0;
+     }
     }
     else
     {
@@ -1021,6 +1064,21 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
      uint8_t mtmp = ((const uint8_t*)mfbyptr)[boff_ ^ 1];
 #endif
      mesh_buf[i] = mtmp;
+
+     if(read_alt)
+     {
+      const uint16_t* afbyptr = afbptr + ((fb_y & 0xFF) << 9);
+      const uint16_t* amfbyptr = amfbptr + ((fb_y & 0xFF) << 9);
+#ifdef MSB_FIRST
+      uint8_t atmp = ((const uint8_t*)afbyptr)[boff_];
+      uint8_t amtmp = ((const uint8_t*)amfbyptr)[boff_];
+#else
+      uint8_t atmp = ((const uint8_t*)afbyptr)[boff_ ^ 1];
+      uint8_t amtmp = ((const uint8_t*)amfbyptr)[boff_ ^ 1];
+#endif
+      alt_buf[i] = 0xFF00 | atmp;
+      alt_mesh_buf[i] = amtmp;
+     }
     }
 
     rot_x += rot_xinc;
@@ -1038,11 +1096,22 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
     {
      buf[i] = 0;
      mesh_buf[i] = 0;
+     if(read_alt)
+     {
+      alt_buf[i] = 0;
+      alt_mesh_buf[i] = 0;
+     }
     }
     else
     {
-     buf[i] = fbptr[(fb_y << 9) + fb_x];
-     mesh_buf[i] = mfbptr[(fb_y << 9) + fb_x];
+     const uint32_t offs = (fb_y << 9) + fb_x;
+     buf[i] = fbptr[offs];
+     mesh_buf[i] = mfbptr[offs];
+     if(read_alt)
+     {
+      alt_buf[i] = afbptr[offs];
+      alt_mesh_buf[i] = amfbptr[offs];
+     }
     }
 
     rot_x += rot_xinc;
@@ -1053,7 +1122,9 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
  else
  {
   const uint16_t* fbyptr = &VDP1_FB[!FBDrawWhich][(line & 0xFF) << 9];
+  const uint16_t* afbyptr = &VDP1_AltFB[!FBDrawWhich][(line & 0xFF) << 9];
   const uint16_t* mfbyptr = &VDP1_MeshFB[!FBDrawWhich][(line & 0xFF) << 9];
+  const uint16_t* amfbyptr = &VDP1_AltMeshFB[!FBDrawWhich][(line & 0xFF) << 9];
 
   if(VDP1_TVMR & VDP1_TVMR_8BPP)
    ret = true;
@@ -1066,13 +1137,21 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
   // the previous scalar for-loop with MDFN_LIKELY was at the mercy
   // of the compiler's autovectorisation heuristics.
   memcpy(buf, fbyptr, (size_t)w * sizeof(uint16_t));
+  if(read_alt)
+   memcpy(alt_buf, afbyptr, (size_t)w * sizeof(uint16_t));
   /* MeshFB row is only ever read by ApplyMeshOverlay (vdp2_render),
    * which is itself gated on VDP1_MeshImproved.  When the option is
    * off this memcpy lands in a buffer nothing reads -- skip it.  At
    * 352-wide x 224 lines x 60Hz that saves ~9.5 MB/s of dead copy
    * traffic in the default state. */
   if(VDP1_MeshImproved)
+  {
    memcpy(mesh_buf, mfbyptr, (size_t)w * sizeof(uint16_t));
+   if(read_alt)
+    memcpy(alt_mesh_buf, amfbyptr, (size_t)w * sizeof(uint16_t));
+  }
+  else if(read_alt)
+   memset(alt_mesh_buf, 0, (size_t)w * sizeof(uint16_t));
  }
 
  //
@@ -1081,15 +1160,21 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
  if(EraseYCounter <= EraseParams.y_end)
  {
   uint16_t* fbyptr;
+  uint16_t* afbyptr;
   uint16_t* mfbyptr;
+  uint16_t* amfbyptr;
   uint32_t x = EraseParams.x_start;
 
   fbyptr = &VDP1_FB[!FBDrawWhich][(EraseYCounter & 0xFF) << 9];
+  afbyptr = &VDP1_AltFB[!FBDrawWhich][(EraseYCounter & 0xFF) << 9];
   mfbyptr = &VDP1_MeshFB[!FBDrawWhich][(EraseYCounter & 0xFF) << 9];
+  amfbyptr = &VDP1_AltMeshFB[!FBDrawWhich][(EraseYCounter & 0xFF) << 9];
   if(EraseParams.rot8)
   {
    fbyptr += (EraseYCounter & 0x100);
+   afbyptr += (EraseYCounter & 0x100);
    mfbyptr += (EraseYCounter & 0x100);
+   amfbyptr += (EraseYCounter & 0x100);
   }
 
   do
@@ -1097,7 +1182,9 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
    for(unsigned sub = 0; sub < 2; sub++)
    {
     fbyptr[x & EraseParams.fb_x_mask] = EraseParams.fill_data;
+    afbyptr[x & EraseParams.fb_x_mask] = EraseParams.fill_data;
     mfbyptr[x & EraseParams.fb_x_mask] = 0;
+    amfbyptr[x & EraseParams.fb_x_mask] = 0;
     x++;
    }
   } while(x < EraseParams.x_bound);
@@ -1408,7 +1495,9 @@ void VDP1_StateAction(StateMem* sm, const unsigned load, const bool data_only)
  {
   SFPTR16N(&(VRAM)[0], (sizeof(VRAM) / sizeof(uint16_t)), "VRAM"),
   SFPTR16N(&(FB)[0][0], (sizeof(FB) / sizeof(uint16_t)), "&FB[0][0]"),
+  SFPTR16N(&(AltFB)[0][0], (sizeof(AltFB) / sizeof(uint16_t)), "&AltFB[0][0]"),
   SFPTR16N(&(MeshFB)[0][0], (sizeof(MeshFB) / sizeof(uint16_t)), "&MeshFB[0][0]"),
+  SFPTR16N(&(AltMeshFB)[0][0], (sizeof(AltMeshFB) / sizeof(uint16_t)), "&AltMeshFB[0][0]"),
   SFVAR(FBDrawWhich),
 
   SFVAR(FBManualPending),
@@ -1504,7 +1593,9 @@ void VDP1_StateAction(StateMem* sm, const unsigned load, const bool data_only)
   EraseParams.x_bound &= 0x7F << 3;
   //
   VDP1_FBDrawWhichPtr = VDP1_FB[FBDrawWhich];
+  VDP1_AltFBDrawWhichPtr = VDP1_AltFB[FBDrawWhich];
   VDP1_MeshFBDrawWhichPtr = VDP1_MeshFB[FBDrawWhich];
+  VDP1_AltMeshFBDrawWhichPtr = VDP1_AltMeshFB[FBDrawWhich];
 
   if(load < 0x00102500)
   {

--- a/mednafen/ss/vdp1.h
+++ b/mednafen/ss/vdp1.h
@@ -60,7 +60,7 @@ MDFN_FASTCALL uint16_t VDP1_Read16_DB(uint32_t A) MDFN_HOT;
 
 void VDP1_SetHBVB(const sscpu_timestamp_t event_timestamp, const bool new_hb_status, const bool new_vb_status);
 
-bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w, uint32_t rot_x, uint32_t rot_y, uint32_t rot_xinc, uint32_t rot_yinc);
+bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, uint16_t* alt_buf, uint16_t* alt_mesh_buf, bool* alt_valid, unsigned w, uint32_t rot_x, uint32_t rot_y, uint32_t rot_xinc, uint32_t rot_yinc);
 
 /* Toggle the "improved mesh transparency" mode for VDP1 mesh-bit
    primitives (mode bit 8 / MSH). When false (default), mesh
@@ -77,6 +77,11 @@ bool VDP1_GetLine(const int line, uint16_t* buf, uint16_t* mesh_buf, unsigned w,
    rasterisation, so no synchronisation is needed. */
 void VDP1_SetMeshImproved(bool improved) MDFN_COLD;
 
+/* Enable capture of the complementary VDP1 double-interlace field for
+   progressive output.  This follows VDP2's current output mode and TVMD
+   interlace setting, so it can change while emulation is running. */
+void VDP1_SetAltFieldCapture(bool enabled);
+
 /* "Improved mesh transparency" toggle storage (libretro core
    option). Defined in vdp1.c; read directly by vdp2_render. */
 MDFN_HIDE extern bool VDP1_MeshImproved;
@@ -88,6 +93,7 @@ MDFN_HIDE extern bool VDP1_MeshImproved;
 
 MDFN_HIDE extern uint16_t VDP1_VRAM[0x40000];
 MDFN_HIDE extern uint16_t VDP1_FB[2][0x20000];
+MDFN_HIDE extern uint16_t VDP1_AltFB[2][0x20000];
 
 #ifdef __cplusplus
 }

--- a/mednafen/ss/vdp1_common.h
+++ b/mednafen/ss/vdp1_common.h
@@ -24,9 +24,13 @@
    Only visible within the vdp1*.c files that include this header. */
 #define VRAM VDP1_VRAM
 #define FB VDP1_FB
+#define AltFB VDP1_AltFB
 #define FBDrawWhichPtr VDP1_FBDrawWhichPtr
+#define AltFBDrawWhichPtr VDP1_AltFBDrawWhichPtr
 #define MeshFB VDP1_MeshFB
+#define AltMeshFB VDP1_AltMeshFB
 #define MeshFBDrawWhichPtr VDP1_MeshFBDrawWhichPtr
+#define AltMeshFBDrawWhichPtr VDP1_AltMeshFBDrawWhichPtr
 #define SysClipX VDP1_SysClipX
 #define SysClipY VDP1_SysClipY
 #define UserClipX0 VDP1_UserClipX0
@@ -68,8 +72,11 @@ int32_t VDP1_CMD_Line(const uint16_t*);
 int32_t VDP1_RESUME_Line(const uint16_t*);
 
 MDFN_HIDE extern uint16_t* VDP1_FBDrawWhichPtr;
+MDFN_HIDE extern uint16_t* VDP1_AltFBDrawWhichPtr;
 MDFN_HIDE extern uint16_t VDP1_MeshFB[2][0x20000];
 MDFN_HIDE extern uint16_t* VDP1_MeshFBDrawWhichPtr;
+MDFN_HIDE extern uint16_t* VDP1_AltMeshFBDrawWhichPtr;
+MDFN_HIDE extern bool VDP1_AltFieldCapture;
 MDFN_HIDE extern int32_t VDP1_SysClipX, VDP1_SysClipY;
 MDFN_HIDE extern int32_t VDP1_UserClipX0, VDP1_UserClipY0, VDP1_UserClipX1, VDP1_UserClipY1;
 MDFN_HIDE extern int32_t VDP1_LocalX, VDP1_LocalY;
@@ -260,8 +267,24 @@ static MDFN_FORCE_INLINE int32_t VDP1_PlotPixel(const int die, const unsigned bp
  {
  int32_t ret = 0;
  uint16_t* fbyptr;
- if(die) { fbyptr = &VDP1_FBDrawWhichPtr[((y >> 1) & 0xFF) << 9]; transparent |= ((y & 1) != (bool)(VDP1_FBCR & VDP1_FBCR_DIL)); }
- else fbyptr = &VDP1_FBDrawWhichPtr[(y & 0xFF) << 9];
+ uint16_t* mfbbase;
+ uint32_t fbrow;
+ if(die)
+ {
+  const bool odd_field = y & 1;
+  const bool use_alt = VDP1_AltFieldCapture && odd_field;
+  fbrow = (y >> 1) & 0xFF;
+  fbyptr = &(use_alt ? VDP1_AltFBDrawWhichPtr : VDP1_FBDrawWhichPtr)[fbrow << 9];
+  mfbbase = use_alt ? VDP1_AltMeshFBDrawWhichPtr : VDP1_MeshFBDrawWhichPtr;
+  if(!VDP1_AltFieldCapture)
+   transparent |= (odd_field != (bool)(VDP1_FBCR & VDP1_FBCR_DIL));
+ }
+ else
+ {
+  fbrow = y & 0xFF;
+  fbyptr = &VDP1_FBDrawWhichPtr[fbrow << 9];
+  mfbbase = VDP1_MeshFBDrawWhichPtr;
+ }
  if(MeshEn) { if(bpp8 || !VDP1_MeshImproved) transparent |= (x ^ y) & 1; }
  if(bpp8) {
   if(MSBOn) { pix = (fbyptr[((x >> 1) & 0x1FF)] | 0x8000) >> (((x & 1) ^ 1) << 3); ret += 5; }
@@ -288,10 +311,10 @@ static MDFN_FORCE_INLINE int32_t VDP1_PlotPixel(const int die, const unsigned bp
    } else { if(GouraudEn) pix = Gourauder_Apply(g, pix); if(HalfFGEn) pix = ((pix & 0x7BDE) >> 1) | (pix & 0x8000); }
   }
   if(MeshEn && !MSBOn && !HalfBGEn && !HalfFGEn && VDP1_MeshImproved) {
-   if(!transparent) { const uint32_t row = die ? ((y >> 1) & 0xFF) : (y & 0xFF); VDP1_MeshFBDrawWhichPtr[(row << 9) + (x & 0x1FF)] = pix; }
+   if(!transparent) mfbbase[(fbrow << 9) + (x & 0x1FF)] = pix;
   } else {
    if(!transparent) *p = pix;
-   if(!MeshEn && VDP1_MeshImproved && !transparent) { const uint32_t row = die ? ((y >> 1) & 0xFF) : (y & 0xFF); VDP1_MeshFBDrawWhichPtr[(row << 9) + (x & 0x1FF)] = 0; }
+   if(!MeshEn && VDP1_MeshImproved && !transparent) mfbbase[(fbrow << 9) + (x & 0x1FF)] = 0;
   }
   ret++;
  }

--- a/mednafen/ss/vdp2.c
+++ b/mednafen/ss/vdp2.c
@@ -53,6 +53,7 @@ extern void SH7095_SetExtHaltDMAKludge(int cpu, bool state);
 
 static bool PAL;
 static sscpu_timestamp_t lastts;
+static unsigned DeinterlaceMode = VDP2_DEINT_NORMAL;
 //
 //
 //
@@ -346,6 +347,16 @@ static INLINE unsigned GetNLVCounter(void)
  return ret;
 }
 
+static INLINE bool ProgressiveOutputActive(void)
+{
+ return DeinterlaceMode == VDP2_DEINT_PROGRESSIVE && InterlaceMode == IM_DOUBLE;
+}
+
+static INLINE void UpdateVDP1AltFieldCapture(void)
+{
+ VDP1_SetAltFieldCapture(ProgressiveOutputActive());
+}
+
 static void LatchHV(void)
 {
  Latched_VCNT = GetNLVCounter();
@@ -558,7 +569,8 @@ static INLINE int32_t AddHCounter(const sscpu_timestamp_t event_timestamp, int32
       }
      }
     }
-    lib->vdp1_hires8 = VDP1_GetLine(VCounter, lib->vdp1_line, lib->vdp1_mesh_line, (HRes & 1) ? 352 : 320, (int32_t)RotParams[0].XstAccum >> 1, (int32_t)RotParams[0].YstAccum >> 1, (int32_t)RotParams[0].DX >> 1, (int32_t)RotParams[0].DY >> 1); // Always call, has side effects.
+    lib->vdp1_hires8 = VDP1_GetLine(VCounter, lib->vdp1_line, lib->vdp1_mesh_line, lib->vdp1_line_alt, lib->vdp1_mesh_line_alt, &lib->vdp1_alt_valid, (HRes & 1) ? 352 : 320, (int32_t)RotParams[0].XstAccum >> 1, (int32_t)RotParams[0].YstAccum >> 1, (int32_t)RotParams[0].DX >> 1, (int32_t)RotParams[0].DY >> 1); // Always call, has side effects.
+    lib->vdp1_alt_hires8 = lib->vdp1_hires8;
     VDP2REND_DrawLine(InternalVB ? -1 : VCounter, CRTLineCounter, !Odd);
     CRTLineCounter++;
    }
@@ -629,6 +641,7 @@ static INLINE void RegsWrite(uint32_t A, uint16_t V)
 	DisplayOn = (V >> 15) & 0x1;
 	BorderMode = (V >> 8) & 0x1;
 	InterlaceMode = (V >> 6) & 0x3;
+	UpdateVDP1AltFieldCapture();
 	VRes = (V >> 4) & 0x3;
 	HRes = (V >> 0) & 0x7;
 	//
@@ -1016,6 +1029,7 @@ void VDP2_Reset(bool powering_up)
  HRes = 0;
  VRes = 0;
  InterlaceMode = 0;
+ UpdateVDP1AltFieldCapture();
 
  VRAMSize = 0;
 
@@ -1082,9 +1096,14 @@ void VDP2_Reset(bool powering_up)
 //
 //
 
-void VDP2_SetDeinterlaceOff(bool off)
+void VDP2_SetDeinterlaceMode(unsigned mode)
 {
- VDP2REND_SetDeinterlaceOff(off);
+ if(mode > VDP2_DEINT_PROGRESSIVE)
+  mode = VDP2_DEINT_NORMAL;
+
+ DeinterlaceMode = mode;
+ UpdateVDP1AltFieldCapture();
+ VDP2REND_SetDeinterlaceMode(mode);
 }
 
 void VDP2_StateAction(StateMem* sm, const unsigned load, const bool data_only)
@@ -1201,6 +1220,7 @@ void VDP2_StateAction(StateMem* sm, const unsigned load, const bool data_only)
 
   CRAM_Mode &= 0x3;
   InterlaceMode &= 0x3;
+  UpdateVDP1AltFieldCapture();
 
   HCounter &= 0x1FF;
   VCounter &= 0x1FF;

--- a/mednafen/ss/vdp2.h
+++ b/mednafen/ss/vdp2.h
@@ -24,6 +24,7 @@
 
 #include "../state.h"
 #include "ss.h"				/* sscpu_timestamp_t, events[], SS_SetEventNT, SS_EVENT_VDP2 */
+#include "vdp2_deinterlace.h"
 
 /* MDFNGI / EmulateSpecStruct: forward-declared rather than pulling
  * in git.h.  This header is C-compat -- the VDP2 subsystem exposes
@@ -51,7 +52,7 @@ void VDP2_Kill(void) MDFN_COLD;
 void VDP2_StateAction(StateMem* sm, const unsigned load, const bool data_only) MDFN_COLD;
 
 void VDP2_Reset(bool powering_up) MDFN_COLD;
-void VDP2_SetDeinterlaceOff(bool off) MDFN_COLD;
+void VDP2_SetDeinterlaceMode(unsigned mode) MDFN_COLD;
 
 sscpu_timestamp_t VDP2_Update(sscpu_timestamp_t timestamp);
 void VDP2_AdjustTS(const int32_t delta);

--- a/mednafen/ss/vdp2_deinterlace.h
+++ b/mednafen/ss/vdp2_deinterlace.h
@@ -1,0 +1,15 @@
+/*******************************************************************************/
+/* Mednafen Sega Saturn Emulation Module                                       */
+/*******************************************************************************/
+
+#ifndef __MDFN_SS_VDP2_DEINTERLACE_H
+#define __MDFN_SS_VDP2_DEINTERLACE_H
+
+enum
+{
+ VDP2_DEINT_NORMAL = 0,
+ VDP2_DEINT_OFF,
+ VDP2_DEINT_PROGRESSIVE
+};
+
+#endif

--- a/mednafen/ss/vdp2_render.c
+++ b/mednafen/ss/vdp2_render.c
@@ -90,29 +90,36 @@ static uint8_t RDBS_Mode;
 static uint8_t VCPRegs[4][8];
 static const uint16_t DummyTileNT[8 * 8 * 4 / sizeof(uint16_t)] = { 0 };
 
-/*
- * "Deinterlace = Off" toggle, read by the consumer thread inside
- * DrawLine. When true and the frame is interlaced, each rendered
- * scanline is also memcpy'd to the opposite-field row of the surface
- * so every emulated frame produces a stable progressive image
- * (current-frame content at full vertical resolution) instead of
- * one field's worth interleaved with the previous frame.
+/* Renderer-side deinterlace output mode.
  *
- * Backport of beetle-psx-libretro's psx_gpu_rasterize_both_fields
- * mechanism. PSX does this by bypassing LineSkipTest in the GPU
- * rasteriser and deferring the per-line VRAM-to-surface conversion
- * to a single end-of-frame flush; Saturn has no equivalent
- * rasterise-vs-scanout split (VDP2 writes RGB directly into the
- * libretro surface as it goes, end-of-frame drain via the WWQ
- * render thread already defers presentation to libretro until all
- * lines are committed). The duplicate-to-mirror-row in DrawLine
- * gives the same user-visible effect: full-resolution, no comb on
- * motion, deinterlacer becomes a no-op.
- *
- * Set via COMMAND_SET_DEINT_OFF on the render-thread command queue
- * (single-producer / single-consumer, no per-line lock).
- */
-static bool DeinterlaceOff;
+ * OFF keeps the older mirror behaviour: draw the current field and copy
+ * it to the opposite row.  PROGRESSIVE renders both fields into one full-height output frame:
+ * for each interlaced source line, draw field 0 to the even output row
+ * and field 1 to the odd output row.  The small line-state snapshots below
+ * are Beetle-specific bookkeeping so the existing DrawLine() logic can
+ * be reused without porting Ymir/Kronos renderer code. */
+static unsigned ProducerDeinterlaceMode = VDP2_DEINT_NORMAL;
+static unsigned ConsumerDeinterlaceMode = VDP2_DEINT_NORMAL;
+
+typedef struct
+{
+ uint32_t VCLast[2];
+ uint32_t YCoordAccum[2];
+ uint32_t CurXScrollIF[2];
+ uint32_t CurYScrollIF[2];
+ uint32_t CurLSA[2];
+ uint32_t CurBackTabAddr;
+ uint32_t CurLCTabAddr;
+ uint16_t CurXCoordInc[2];
+ uint16_t NBG23_YCounter[2];
+ uint16_t CurBackColor;
+ uint16_t CurLCColor;
+ uint32_t WindowCurLineWinAddr[2];
+ uint8_t MosaicVCount;
+} VDP2LineState;
+
+static VDP2LineState ProgressiveLineState[2];
+static bool ProgressiveLineStateValid[2];
 
 static uint16_t BGON;
 static uint16_t MZCTL;
@@ -4011,6 +4018,46 @@ static int32_t ApplyHBlend(uint32_t* const target, int32_t w)
  #undef BHALF
 }
 
+static INLINE void SaveLineState(VDP2LineState* st)
+{
+ for(unsigned n = 0; n < 2; n++)
+ {
+  st->VCLast[n] = VCLast[n];
+  st->YCoordAccum[n] = YCoordAccum[n];
+  st->CurXScrollIF[n] = CurXScrollIF[n];
+  st->CurYScrollIF[n] = CurYScrollIF[n];
+  st->CurLSA[n] = CurLSA[n];
+  st->CurXCoordInc[n] = CurXCoordInc[n];
+  st->NBG23_YCounter[n] = NBG23_YCounter[n];
+  st->WindowCurLineWinAddr[n] = Window[n].CurLineWinAddr;
+ }
+ st->CurBackTabAddr = CurBackTabAddr;
+ st->CurLCTabAddr = CurLCTabAddr;
+ st->CurBackColor = CurBackColor;
+ st->CurLCColor = CurLCColor;
+ st->MosaicVCount = MosaicVCount;
+}
+
+static INLINE void LoadLineState(const VDP2LineState* st)
+{
+ for(unsigned n = 0; n < 2; n++)
+ {
+  VCLast[n] = st->VCLast[n];
+  YCoordAccum[n] = st->YCoordAccum[n];
+  CurXScrollIF[n] = st->CurXScrollIF[n];
+  CurYScrollIF[n] = st->CurYScrollIF[n];
+  CurLSA[n] = st->CurLSA[n];
+  CurXCoordInc[n] = st->CurXCoordInc[n];
+  NBG23_YCounter[n] = st->NBG23_YCounter[n];
+  Window[n].CurLineWinAddr = st->WindowCurLineWinAddr[n];
+ }
+ CurBackTabAddr = st->CurBackTabAddr;
+ CurLCTabAddr = st->CurLCTabAddr;
+ CurBackColor = st->CurBackColor;
+ CurLCColor = st->CurLCColor;
+ MosaicVCount = st->MosaicVCount;
+}
+
 static NO_INLINE void DrawLine(const uint16_t out_line, const uint16_t vdp2_line, const bool field)
 {
  const int32_t tvdw = ((!CorrectAspect || Clock28M) ? 352 : 330) << ((HRes & 0x2) >> 1);
@@ -4256,7 +4303,10 @@ static NO_INLINE void DrawLine(const uint16_t out_line, const uint16_t vdp2_line
   //  has no user-layer-mask UI; the bit was always set, so the else
   //  was always dead.  Sprite draw runs unconditionally now.)
   MakeSpriteCCLUT();
-  DrawSpriteData[(HRes & 0x2) >> 0x1][(SDCTL >> 8) & 0x1][SPCTL_Low](LIB[vdp2_line].vdp1_line, LIB[vdp2_line].vdp1_hires8, w);
+  {
+   const bool use_vdp1_alt = (ConsumerDeinterlaceMode == VDP2_DEINT_PROGRESSIVE) && espec->InterlaceOn && (InterlaceMode == IM_DOUBLE) && field && LIB[vdp2_line].vdp1_alt_valid;
+   DrawSpriteData[(HRes & 0x2) >> 0x1][(SDCTL >> 8) & 0x1][SPCTL_Low](use_vdp1_alt ? LIB[vdp2_line].vdp1_line_alt : LIB[vdp2_line].vdp1_line, use_vdp1_alt ? LIB[vdp2_line].vdp1_alt_hires8 : LIB[vdp2_line].vdp1_hires8, w);
+  }
 
   if(BGON & 0x30)
   {
@@ -4592,7 +4642,10 @@ static NO_INLINE void DrawLine(const uint16_t out_line, const uint16_t vdp2_line
    // zeroed unconditionally by VBErase, so flipping the option on
    // mid-session can't bleed stale data through.
    if(VDP1_MeshImproved)
-    ApplyMeshOverlay(target + tvxo, LIB[vdp2_line].vdp1_mesh_line, LIB[vdp2_line].vdp1_winprio, w, (HRes & 0x2) >> 1);
+   {
+    const bool use_vdp1_alt = (ConsumerDeinterlaceMode == VDP2_DEINT_PROGRESSIVE) && espec->InterlaceOn && (InterlaceMode == IM_DOUBLE) && field && LIB[vdp2_line].vdp1_alt_valid;
+    ApplyMeshOverlay(target + tvxo, use_vdp1_alt ? LIB[vdp2_line].vdp1_mesh_line_alt : LIB[vdp2_line].vdp1_mesh_line, LIB[vdp2_line].vdp1_winprio, w, (HRes & 0x2) >> 1);
+   }
   }
   //
   //
@@ -4647,7 +4700,7 @@ static NO_INLINE void DrawLine(const uint16_t out_line, const uint16_t vdp2_line
  // DisplayRect.x + LineWidths <= 704 (asserted in DrawLine just
  // above).
  //
- if(MDFN_UNLIKELY(DeinterlaceOff) && espec->InterlaceOn)
+ if(MDFN_UNLIKELY(ConsumerDeinterlaceMode == VDP2_DEINT_OFF) && espec->InterlaceOn)
  {
   const int32_t mirror_line = (int32_t)out_line ^ 1;
   const int32_t rect_end = espec->DisplayRect.y + espec->DisplayRect.h;
@@ -4668,6 +4721,24 @@ static NO_INLINE void DrawLine(const uint16_t out_line, const uint16_t vdp2_line
 //
 //
 //
+static INLINE void DrawLineCommand(const uint16_t out_line, const uint16_t vdp2_line, const bool field)
+{
+ if(MDFN_UNLIKELY(ConsumerDeinterlaceMode == VDP2_DEINT_PROGRESSIVE && espec && espec->InterlaceOn))
+ {
+  const unsigned f = (unsigned)field & 1U;
+
+  if(ProgressiveLineStateValid[f])
+   LoadLineState(&ProgressiveLineState[f]);
+
+  DrawLine(out_line, vdp2_line, field);
+
+  SaveLineState(&ProgressiveLineState[f]);
+  ProgressiveLineStateValid[f] = true;
+ }
+ else
+  DrawLine(out_line, vdp2_line, field);
+}
+
 static sthread_t *RThread = NULL;
 
 enum
@@ -4678,7 +4749,7 @@ enum
 
  COMMAND_DRAW_LINE,
 
- COMMAND_SET_DEINT_OFF,
+ COMMAND_SET_DEINT_MODE,
 
  COMMAND_SET_BUSYWAIT,
 
@@ -4850,7 +4921,7 @@ static void/*int*/ RThreadEntry(void* data)
 
    case COMMAND_DRAW_LINE:
 	//for(unsigned i = 0; i < 2; i++)
-	DrawLine((uint16_t)wqe->Arg32, wqe->Arg32 >> 16, wqe->Arg16);
+	DrawLineCommand((uint16_t)wqe->Arg32, wqe->Arg32 >> 16, wqe->Arg16);
 	//
 	// Publish completion: DrawFinishCount is consumer-written, read by
 	// the producer (EndFrame's drain wait, and the wdcq wakeup
@@ -4873,8 +4944,8 @@ static void/*int*/ RThreadEntry(void* data)
 	Reset(wqe->Arg32);
 	break;
 
-   case COMMAND_SET_DEINT_OFF:
-	DeinterlaceOff = (bool)wqe->Arg32;
+   case COMMAND_SET_DEINT_MODE:
+	ConsumerDeinterlaceMode = wqe->Arg32;
 	break;
 
    case COMMAND_SET_BUSYWAIT:
@@ -5018,6 +5089,8 @@ void VDP2REND_StartFrame(struct EmulateSpecStruct* espec_arg, const bool clock28
 {
  NextOutLine = 0;
  Clock28M = clock28m;
+ ProgressiveLineStateValid[0] = false;
+ ProgressiveLineStateValid[1] = false;
 
  espec = espec_arg;
 
@@ -5065,17 +5138,33 @@ void VDP2REND_EndFrame(void)
 
  if(NextOutLine < VisibleLines)
  {
+  const bool progressive = (ProducerDeinterlaceMode == VDP2_DEINT_PROGRESSIVE && espec->InterlaceOn);
+
   do
   {
-   uint16_t out_line = NextOutLine;
-   uint32_t* target;
+   if(progressive)
+   {
+    for(unsigned f = 0; f < 2; f++)
+    {
+     const uint16_t out_line = (NextOutLine << 1) | f;
+     uint32_t* target = espec->surface->pixels + out_line * espec->surface->pitchinpix;
 
-   if(espec->InterlaceOn)
-    out_line = (out_line << 1) | espec->InterlaceField;
+     target[0] = target[1] = target[2] = target[3] = MAKECOLOR(0, 0, 0, 0);
+     espec->LineWidths[out_line] = 4;
+    }
+   }
+   else
+   {
+    uint16_t out_line = NextOutLine;
+    uint32_t* target;
 
-   target = espec->surface->pixels + out_line * espec->surface->pitchinpix;
-   target[0] = target[1] = target[2] = target[3] = MAKECOLOR(0, 0, 0, 0);
-   espec->LineWidths[out_line] = 4;
+    if(espec->InterlaceOn)
+     out_line = (out_line << 1) | espec->InterlaceField;
+
+    target = espec->surface->pixels + out_line * espec->surface->pitchinpix;
+    target[0] = target[1] = target[2] = target[3] = MAKECOLOR(0, 0, 0, 0);
+    espec->LineWidths[out_line] = 4;
+   }
   } while(++NextOutLine < VisibleLines);
  }
 
@@ -5101,15 +5190,29 @@ void VDP2REND_DrawLine(const int vdp2_line, const uint32_t crt_line, const bool 
 
  if(MDFN_LIKELY(crt_line < VisibleLines))
  {
-  uint16_t out_line = crt_line;
-
-  if(espec->InterlaceOn)
-   out_line = (out_line << 1) | espec->InterlaceField;
-
+  const bool progressive = (ProducerDeinterlaceMode == VDP2_DEINT_PROGRESSIVE && espec->InterlaceOn);
+  const unsigned queued_lines = progressive ? 2U : 1U;
   const uint32_t wdcq = Prod.DrawPushLocal - VDP2_ATOMIC_LOAD_ACQ(DrawFinishCount);
-  ++Prod.DrawPushLocal;
+
+  Prod.DrawPushLocal += queued_lines;
   VDP2_ATOMIC_STORE_REL(DrawPushCount, Prod.DrawPushLocal);
-  WWQ(COMMAND_DRAW_LINE, ((uint16_t)vdp2_line << 16) | out_line, field);
+
+  if(progressive)
+  {
+   const uint16_t base_out_line = crt_line << 1;
+
+   WWQ(COMMAND_DRAW_LINE, ((uint16_t)vdp2_line << 16) | (base_out_line | 0), false);
+   WWQ(COMMAND_DRAW_LINE, ((uint16_t)vdp2_line << 16) | (base_out_line | 1), true);
+  }
+  else
+  {
+   uint16_t out_line = crt_line;
+
+   if(espec->InterlaceOn)
+    out_line = (out_line << 1) | espec->InterlaceField;
+
+   WWQ(COMMAND_DRAW_LINE, ((uint16_t)vdp2_line << 16) | out_line, field);
+  }
   //
   //
   if(crt_line == bwthresh)
@@ -5121,9 +5224,9 @@ void VDP2REND_DrawLine(const int vdp2_line, const uint32_t crt_line, const bool 
   {
    if(wdcq == 0)
     DoWakeupIfNecessary = true;
-   else if((wdcq + 1) >= 64 && DoWakeupIfNecessary)
+   else if((wdcq + queued_lines) >= 64 && DoWakeupIfNecessary)
    {
-    //printf("Post Wakeup: %3d --- crt_line=%3d\n", wdcq + 1, crt_line);
+    //printf("Post Wakeup: %3d --- crt_line=%3d\n", wdcq + queued_lines, crt_line);
     ssem_signal(WakeupSem);
     DoWakeupIfNecessary = false;
    }
@@ -5138,40 +5241,21 @@ void VDP2REND_Reset(bool powering_up)
  WWQ(COMMAND_RESET, powering_up, 0);
 }
 
-void VDP2REND_SetDeinterlaceOff(bool off)
+void VDP2REND_SetDeinterlaceMode(unsigned mode)
 {
- // Normally routed through the consumer command queue (not a direct
- // atomic store) so the flag flips exactly between scanlines, never
- // mid-line.
- //
- // Pre-Init path (RThread NULL): libretro's check_variables(true)
- // fires from retro_load_game *before* MDFNI_LoadGame brings up
- // VDP2REND_Init, so a WWQ here would land in a ring that
- // VDP2REND_Init then zeroes out (Prod/Cons reset, WQ_PushCount
- // store=0) before the consumer thread is ever created and starts
- // pulling. The COMMAND_SET_DEINT_OFF entry stays in WQ[0] memory
- // but is unreachable: the consumer sees PushCount==PopLocal==0 on
- // startup and waits.
- //
- // Without this guard, the very first frames after boot run with
- // DeinterlaceOff = false even when the user has the option set
- // to "off". On interlaced content (VF Kids, anything that flips
- // TVMD into IM_DOUBLE) the mirror at DrawLine never fires and
- // VDP2 just writes one field per frame on top of the previous
- // field's lines -- weave-style combing, visible on VDP1 polygon
- // output. Toggling the option mid-run re-fires SetDeinterlaceOff
- // from check_variables(false) when the WQ is alive, which is why
- // cycling the option through any other mode and back to "off"
- // appears to "fix" the combing (it actually engages the mirror
- // for the first time since boot).
- //
- // The pre-Init write is unsynchronized but safe: no consumer
- // thread exists yet, and the only writer is the emulator main
- // thread (the same one that will create RThread shortly).
- if (RThread == NULL)
-  DeinterlaceOff = off;
+ if(mode > VDP2_DEINT_PROGRESSIVE)
+  mode = VDP2_DEINT_NORMAL;
+
+ ProducerDeinterlaceMode = mode;
+
+ /* Route the consumer copy through the queue when the render thread is
+  * alive, so option changes are observed between draw commands.  Before
+  * Init creates the thread, write directly; an early queued command would
+  * be lost when Init resets the ring counters. */
+ if(RThread == NULL)
+  ConsumerDeinterlaceMode = mode;
  else
-  WWQ(COMMAND_SET_DEINT_OFF, (uint32_t)off, 0);
+  WWQ(COMMAND_SET_DEINT_MODE, mode, 0);
 }
 
 void VDP2REND_Write8_DB(uint32_t A, uint16_t DB)

--- a/mednafen/ss/vdp2_render.h
+++ b/mednafen/ss/vdp2_render.h
@@ -23,6 +23,7 @@
 #define __MDFN_SS_VDP2_RENDER_H
 
 #include "../state.h"
+#include "vdp2_deinterlace.h"
 /* git.h is no longer used (CheatFormatStruct's std::exception,
  * GameDB_Entry's std::vector, etc.).  This header now needs to
  * parse as C because vdp2.c (formerly vdp2.c) includes it.
@@ -42,7 +43,7 @@ void VDP2REND_GetGunXTranslation(const bool clock28m, float* scale, float* offs)
 void VDP2REND_StartFrame(struct EmulateSpecStruct* espec, const bool clock28m, const int SurfInterlaceField);
 void VDP2REND_EndFrame(void);
 void VDP2REND_Reset(bool powering_up) MDFN_COLD;
-void VDP2REND_SetDeinterlaceOff(bool off) MDFN_COLD;
+void VDP2REND_SetDeinterlaceMode(unsigned mode) MDFN_COLD;
 
 /* Array reference parameters (uint16_t (&rr)[0x100] etc.) replaced
  * with plain pointers: the body indexes rr[i] (works with the
@@ -75,8 +76,11 @@ struct VDP2Rend_LIB
 {
  struct VDP2Rend_RotVars rv[2];
  bool vdp1_hires8;
+ bool vdp1_alt_hires8;
+ bool vdp1_alt_valid;
  bool win_ymet[2];
  uint16_t vdp1_line[352];
+ uint16_t vdp1_line_alt[352];
  // Mesh side-buffer scanline staged here by VDP1_GetLine when the
  // improved-mesh-transparency option is on. Per-pixel: raw VDP1 texel
  // (CRAM offset / colour-bank-OR / priority-CC bits for paletted types
@@ -85,6 +89,7 @@ struct VDP2Rend_LIB
  // T_DrawSpriteData would and 50%-blends the result onto the surface.
  // All zeros when the option is off.
  uint16_t vdp1_mesh_line[352];
+ uint16_t vdp1_mesh_line_alt[352];
  // Winning-layer priority per output pixel, captured at T_MixIt's
  // terminal store. ApplyMeshOverlay reads this to gate the mesh blend:
  // a mesh pixel is suppressed where a higher-priority VDP2 layer

--- a/mednafen/video/Deinterlacer.h
+++ b/mednafen/video/Deinterlacer.h
@@ -65,12 +65,11 @@ enum
  *                 adaptive blending against a two-frame history.
  *                 Surface height presented to libretro is full
  *                 interlaced height.
- *   - OFF:        no-op in the deinterlacer itself; pairs with
- *                 VDP2REND_SetDeinterlaceOff(true) on the renderer
- *                 side, which mirrors each rendered scanline to the
- *                 opposite-field row of the surface so both row-block
- *                 stripes hold current-frame content.  Surface height
- *                 presented to libretro is full interlaced height.
+ *   - OFF:        no-op in the deinterlacer itself; used by renderer-side
+ *                 modes that already fill the full interlaced-height
+ *                 surface, such as the mirror/off path and the progressive
+ *                 renderer path.  Surface height presented to libretro is
+ *                 full interlaced height.
  *
  * WEAVE, BOB_OFFSET, FASTMAD and OFF all produce a full-height
  * surface; the libretro bridge must set PrevInterlaced=true for all


### PR DESCRIPTION
This PR adds a new `Progressive` option to the deinterlacer setting.

The goal is to build a full-height progressive frame from both interlace fields instead of mirroring only the current field.

The VDP2 side renders both fields into their matching output lines.

For VDP1 double-interlace output, the complementary field is preserved in an alternate framebuffer, then even/odd VDP1 lines are mapped to the matching progressive output field. This fixes high-resolution VDP1 objects bobbing/jumping in games such as:

- Virtua Fighter 2
- Virtua Fighter Kids

This was inspired by looking at how Kronos/MAME/Ymir handles progressive/deinterlaced output, especially the idea of keeping the complementary VDP1 field available for composition.

The implementation was prototyped with AI assistance, so if maintainers prefer to clean it up, correct it, split it differently, or even redo the PR from scratch, that is totally fine. I mainly wanted to provide a working reference implementation and test case for the issue.

Existing `Off`, `Bob`, and `Weave` modes should remain unchanged.

Closes https://github.com/libretro/beetle-saturn-libretro/issues/78

You can test my build here : https://github.com/Immersion95/beetle-saturn-libretro/actions/runs/27492144751