### PR TITLE
gitlab-ci: disable LTO for Windows builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,12 @@
     JNI_PATH: .
     CORENAME: mednafen_saturn
 
+# Windows MinGW builds currently hit a GCC LTO rendering regression.
+# Keep the shared libretro templates unchanged and only pass LTO= to make.
+.windows-no-lto:
+  variables:
+    MAKEFLAGS: "LTO="
+
 # Inclusion templates, required for the build to work
 include:
   ################################## DESKTOPS ################################
@@ -76,12 +82,14 @@ libretro-build-windows-x64:
   extends:
     - .libretro-windows-x64-mingw-make-default
     - .core-defs
+    - .windows-no-lto
     
 # Windows 32-bit
 libretro-build-windows-i686:
   extends:
     - .libretro-windows-i686-mingw-make-default
     - .core-defs
+    - .windows-no-lto
 
 # Linux 64-bit
 libretro-build-linux-x64:


### PR DESCRIPTION
This PR disables LTO for the GitLab Windows MinGW builds.

It is related to this issue:
https://github.com/libretro/beetle-saturn-libretro/issues/77

Street Fighter Zero 3 (Japan) currently shows a temporary yellow tint on Windows x64 when the core is built with GCC LTO enabled.

I tested the same commit with different Windows x64 builds:

* `LTO=`: correct rendering, no yellow tint
* default `LTO=1`: yellow tint appears
* `LTO=1` without `-fipa-pta`: yellow tint still appears

So the issue does not seem to be caused by `-fipa-pta` specifically. It appears to be triggered by GCC LTO itself, or by an LTO-sensitive issue in the video renderer/state handling.

The goal of this commit is simple: make the official GitLab Windows builds match the stable non-LTO behavior. Since LTO can change optimization across multiple files, it may also cause other subtle regressions compared to non-LTO builds. Disabling it for Windows is a safer default until the exact LTO-sensitive code path is identified.

This PR does not change the existing libretro GitLab CI templates or build recipes. It only passes `LTO=` through `MAKEFLAGS` for the Windows jobs.

Only the Windows GitLab jobs are changed:

* `libretro-build-windows-x64`
* `libretro-build-windows-i686`

Linux, macOS, Android, iOS, tvOS and webOS builds are left unchanged (couldn't test if it was affected by the bug initially).