### PR TITLE
Increase DriveCounter value for CDIF startup

### DIFF
--- a/mednafen/ss/cdb.c
+++ b/mednafen/ss/cdb.c
@@ -1948,7 +1948,7 @@ static void Drive_Run(int64_t clocks)
 	{
          CurPosInfo.status = STATUS_BUSY;
 	 DrivePhase = DRIVEPHASE_STARTUP;
-	 DriveCounter = (int64_t)(1 * 44100 * 256) << 32;
+	 DriveCounter = (int64_t)(2 * 44100 * 256) << 32;
 	}
 	else
 	 DriveCounter = (int64_t)1000 << 32;


### PR DESCRIPTION
This increase of the timeout before the drive starts reading on the "insert" of a cd is in the hope it will fix issue #81

Edit: for the future, if you feel tempted to merge, dont, this pr is unneeded, the real cause was chd not being supported for libretro vfs in beetle saturn.