### PR TITLE
ss: fix writable-memory cache bypass lookup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,12 +10,6 @@
     JNI_PATH: .
     CORENAME: mednafen_saturn
 
-# Windows MinGW builds currently hit a GCC LTO rendering regression.
-# Keep the shared libretro templates unchanged and only pass LTO= to make.
-.windows-no-lto:
-  variables:
-    MAKEFLAGS: "LTO="
-
 # Inclusion templates, required for the build to work
 include:
   ################################## DESKTOPS ################################
@@ -82,14 +76,12 @@ libretro-build-windows-x64:
   extends:
     - .libretro-windows-x64-mingw-make-default
     - .core-defs
-    - .windows-no-lto
     
 # Windows 32-bit
 libretro-build-windows-i686:
   extends:
     - .libretro-windows-i686-mingw-make-default
     - .core-defs
-    - .windows-no-lto
 
 # Linux 64-bit
 libretro-build-linux-x64:

--- a/mednafen/ss/sh7095.inc
+++ b/mednafen/ss/sh7095.inc
@@ -4152,7 +4152,7 @@ static INLINE uint32_t SH7095_Cache_ReadAddressArray(SH7095* z, uint32_t A)
 	 z->Cache_LRU[(A >> 4) & 0x3F] = (z->Cache_LRU[(A >> 4) & 0x3F] & LRU_Update_Tab[way_match].AND) | LRU_Update_Tab[way_match].OR;	\
 														\
          /* Ugggghhhh.... */											\
-         if(CacheBypassHack && FMIsWriteable[A >> SH7095_EXT_MAP_GRAN_BITS])					\
+         if(CacheBypassHack && FMIsWriteable_get(A >> SH7095_EXT_MAP_GRAN_BITS))				\
 	 {													\
           retval = SH7095_RBO_BE_T(T, SH7095_FastMap[A >> SH7095_EXT_MAP_GRAN_BITS], A);				\
 	  goto MemReturn;											\

--- a/mednafen/ss/ss_init.h
+++ b/mednafen/ss/ss_init.h
@@ -59,9 +59,9 @@
 extern uintptr_t SH7095_FastMap[1U << (32 - SH7095_EXT_MAP_GRAN_BITS)];
 
 /* Per-FastMap-slot writeable bit (packed 1-bit-per-slot bitmap).
- * sh7095.inc reads the array directly for the CacheBypassHack
- * path; the SetFastMemMap setup path writes it.  Was std::bitset;
- * replaced by uint32_t[] packed bitfield. */
+ * sh7095.inc reads it for the CacheBypassHack path; the SetFastMemMap
+ * setup path writes it.  Was std::bitset; replaced by uint32_t[]
+ * packed bitfield. */
 #define FMISWRITEABLE_BITS (1U << (27 - SH7095_EXT_MAP_GRAN_BITS))
 extern uint32_t FMIsWriteable[FMISWRITEABLE_BITS / 32];
 
@@ -93,6 +93,11 @@ extern sscpu_timestamp_t next_event_ts;
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+static INLINE bool FMIsWriteable_get(uint32_t i)
+{
+ return (FMIsWriteable[i >> 5] >> (i & 31)) & 1;
+}
 
 static INLINE void FMIsWriteable_set(uint32_t i, bool v)
 {


### PR DESCRIPTION
Commit 01f479e converted `FMIsWriteable` from `std::bitset` to a packed `uint32_t bitmap`, but left one SH-2 cache-bypass path indexing it as an unpacked array. This causes an out-of-bounds read and may return stale cache data. 
With GCC 11 LTO, Street Fighter Zero 3 consequently leaves the VDP2 blue color offset at -256, producing the temporary yellow tint shown below.

Restore the packed-bit getter and use it in the cache-bypass condition. 

The fix was verified at 8f0d69a and current master with unchanged GCC 11 LTO. Since the underlying bug is fixed, also remove the Windows no-LTO workaround added by PR #80.
The screenshots show the same transition frame before and after the fix.

<img width="352" height="224" alt="before-frame-3232" src="https://github.com/user-attachments/assets/018fabab-1aec-4edc-b277-2d87a3765e59" />
<img width="352" height="224" alt="after-frame-3232" src="https://github.com/user-attachments/assets/f79de2fa-448d-47e1-8440-e5672e70165c" />


Fixes #77.