### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -95,6 +99,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of Beetle Saturn, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of the Makefile is arch-neutral (the only `__x86_64__` define is in the MSVC branch), there is no x86 assembly in the build, and `android-arm64-v8a`, `osx-arm64`, `ios-arm64` and `tvos-arm64` already build these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include. (The file uses CRLF line endings; the patch keeps them.)

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 / Adreno 618 Chromebook, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `mednafen_saturn_libretro.so` (ELF 64-bit ARM aarch64). In RetroArch 1.22.2 the core boots a real disc end to end - Daytona USA (USA), Redump multi-track cue - through the US BIOS into the attract mode at 352x224, **59.66 fps**, 3953 frames rendered with 48 dropped. Screenshot of the running attract screen attached below.
